### PR TITLE
fix: handle all URL types in content monitor

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -170,10 +170,9 @@ def check_url(entry: dict) -> dict:
 
     if url_type == "github_repo":
         return check_github_repo(url)
-    elif url_type in ("published_doc", "draft_doc") or url_type == "forum":
-        return check_http_resource(url, hash_body=True)
     else:
-        return {"error": f"Onbekend type: {url_type}"}
+        # Alle niet-GitHub URLs als HTTP resource checken
+        return check_http_resource(url, hash_body=True)
 
 
 def load_checksums(path: Path) -> dict:


### PR DESCRIPTION
## Summary
- Content monitoring reported errors because `check_url()` only handled `github_repo`, `published_doc`, `draft_doc` and `forum` types
- URLs with types `geonovum_doc`, `geonovum_site` and `pdok` were rejected as "Onbekend type"
- Changed `check_url()` to treat all non-GitHub URLs as HTTP resources

## Test plan
- [x] Existing tests pass (57/57)
- [ ] Next monitoring run should report 0 errors