### PR TITLE
fix: normaliseer Liferay CMS dynamische content

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -93,6 +93,11 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
     # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
     html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
+    # Liferay CMS: authToken / p_auth CSRF token (verandert per request)
+    html = re.sub(r"Liferay\.authToken\s*=\s*'[^']*'", "Liferay.authToken = 'TOKEN'", html)
+    html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
+    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422)
+    html = re.sub(r"\?t=\d{10,15}", "?t=TIMESTAMP", html)
     return html
 
 

--- a/tests/test_monitor_content.py
+++ b/tests/test_monitor_content.py
@@ -92,6 +92,24 @@ class TestNormalizeHtml:
         assert "c838df03" not in result
         assert '"permissionsHash":"HASH"' in result
 
+    def test_liferay_auth_token(self):
+        html = "Liferay.authToken = '9zmfQSYt';"
+        result = normalize_html(html)
+        assert "9zmfQSYt" not in result
+        assert "Liferay.authToken = 'TOKEN'" in result
+
+    def test_liferay_p_auth_hidden_field(self):
+        html = '<input type="hidden" name="p_auth" value="9zmfQSYt"/>'
+        result = normalize_html(html)
+        assert "9zmfQSYt" not in result
+        assert 'name="p_auth" value="TOKEN"' in result
+
+    def test_liferay_cache_bust_timestamp(self):
+        html = '<img src="/documents/3-32ca-89fd?t=1771832749422" alt="Logo">'
+        result = normalize_html(html)
+        assert "1771832749422" not in result
+        assert "?t=TIMESTAMP" in result
+
     def test_gewone_content_behouden(self):
         html = "<h1>Digikoppeling Architectuur</h1><p>Standaard tekst.</p>"
         assert normalize_html(html) == html

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "geonovum-plugin"
-version = "0.1.0"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- Voegt drie normalisatieregels toe aan `normalize_html()` voor Liferay CMS (gebruikt door PDOK):
  - `Liferay.authToken` CSRF token
  - `p_auth` hidden form field
  - `?t=TIMESTAMP` cache-bust parameters op resource URLs
- Voegt tests toe voor alle drie patronen

## Test plan

- [x] Bestaande 60 tests passen
- [x] Ruff lint is schoon
- [x] Geverifieerd tegen live PDOK-pagina: twee opeenvolgende fetches produceren nu identieke hashes

Fixes #6