### PR TITLE
Update repo references for org move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Changelog
 
-## [0.1.3](https://github.com/MinBZK/geonovum-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
+## [0.1.3](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
 
 
 ### Opgelost
 
-* normaliseer Liferay CMS dynamische content om false positives te voorkomen ([#7](https://github.com/MinBZK/geonovum-plugin/issues/7)) ([cfee546](https://github.com/MinBZK/geonovum-plugin/commit/cfee546d6d6234046a7751bd8aa74400074905c0)), closes [#6](https://github.com/MinBZK/geonovum-plugin/issues/6)
+* normaliseer Liferay CMS dynamische content om false positives te voorkomen ([#7](https://github.com/developer-overheid-nl/geo-plugin/issues/7)) ([cfee546](https://github.com/developer-overheid-nl/geo-plugin/commit/cfee546d6d6234046a7751bd8aa74400074905c0)), closes [#6](https://github.com/developer-overheid-nl/geo-plugin/issues/6)
 
-## [0.1.2](https://github.com/MinBZK/geonovum-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
-
-
-### Opgelost
-
-* handle all URL types in content monitor ([#4](https://github.com/MinBZK/geonovum-plugin/issues/4)) ([c989785](https://github.com/MinBZK/geonovum-plugin/commit/c989785e598879c2b752fe265ea276044616fd0d))
-
-## [0.1.1](https://github.com/MinBZK/geonovum-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+## [0.1.2](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
 
 
 ### Opgelost
 
-* corrigeer PDOK tabel, Atom URL, repo namen en BGT governance ([96db6e3](https://github.com/MinBZK/geonovum-plugin/commit/96db6e3ca97deec87710e1e6a5a9ddde07a888b3))
+* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/geo-plugin/issues/4)) ([c989785](https://github.com/developer-overheid-nl/geo-plugin/commit/c989785e598879c2b752fe265ea276044616fd0d))
+
+## [0.1.1](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+
+
+### Opgelost
+
+* corrigeer PDOK tabel, Atom URL, repo namen en BGT governance ([96db6e3](https://github.com/developer-overheid-nl/geo-plugin/commit/96db6e3ca97deec87710e1e6a5a9ddde07a888b3))
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ```bash
 # Via de overheid-plugins marketplace (aanbevolen)
-claude plugin marketplace add MinBZK/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
 claude plugin install geonovum@overheid-plugins
 
 # Per sessie
-git clone https://github.com/MinBZK/geonovum-plugin.git
-claude --plugin-dir ./geonovum-plugin
+git clone https://github.com/developer-overheid-nl/geo-plugin.git
+claude --plugin-dir ./geo-plugin
 ```
 
 ## Skills
@@ -46,7 +46,7 @@ De skills zijn gebaseerd op:
 
 ## Onderdeel van
 
-Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/MinBZK/overheid-claude-plugins) marketplace.
+Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/developer-overheid-nl/overheid-claude-plugins) marketplace.
 
 ## Licentie
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -41,10 +41,10 @@ localisation:
   localisationReady: false
 maintenance:
   contacts:
-    - name: MinBZK
+    - name: developer-overheid-nl
   type: community
-name: geonovum-plugin
+name: geo-plugin
 releaseDate: '2026-02-22'
 softwareVersion: 0.1.3
 softwareType: standalone/other
-url: https://github.com/MinBZK/geonovum-plugin
+url: https://github.com/developer-overheid-nl/geo-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "geonovum-plugin"
+name = "geo-plugin"
 version = "0.1.3"
 description = "Geonovum Claude Code Plugin - Geo-standaarden voor ruimtelijke data in Nederland"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 ]
 
 [[package]]
-name = "geonovum-plugin"
+name = "geo-plugin"
 version = "0.1.2"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Updated all references from `MinBZK/geonovum-plugin` to `developer-overheid-nl/geo-plugin` across README.md, CHANGELOG.md, publiccode.yml, pyproject.toml, and uv.lock
- Updated git remote URL, clone instructions, marketplace references, and contact org name
- Reflects the repository move from MinBZK to developer-overheid-nl organization

## Test plan
- [ ] Verify all links in README.md point to the correct repository
- [ ] Verify CHANGELOG.md links resolve correctly
- [ ] Verify publiccode.yml passes validation
- [ ] Verify `uv lock` still works with the renamed package