### PR TITLE
Fix monitoring false positives en duplicate issue-aanmaak

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -10,6 +10,7 @@ Maakt GitHub Issues aan bij gedetecteerde wijzigingen.
 """
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -295,10 +296,8 @@ def manage_issue(
     )
     existing_issues: list[dict] = []
     if result.returncode == 0 and result.stdout.strip():
-        try:
+        with contextlib.suppress(json.JSONDecodeError):
             existing_issues = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            pass
 
     for change in changes:
         title = change["title"]


### PR DESCRIPTION
## Summary

- **HTML-normalisatie uitgebreid**: Sentry tracing meta tags, Next.js RSC streaming scripts en Next.js escaped JSON nonces worden nu gestript. Deze elementen veranderen per request en veroorzaakten false positive content-change alerts.
- **Duplicate issue-detectie gefixt**: De `manage_issue` functie gebruikte `gh issue list --search` om bestaande issues te vinden, maar GitHub's search API faalt op titels met speciale tekens (`-`, `/`, `(`, `)`). Vervangen door een enkele bulk-fetch van alle open monitoring issues met exact title matching in Python.
- **Intra-run duplicate preventie**: Nieuw aangemaakte issues worden bijgehouden binnen dezelfde run, zodat meerdere wijzigingen niet elk een eigen issue aanmaken.

## Test plan

- [ ] Draai `monitor_content.py --dry-run` tegen het manifest en controleer dat NCSC/Next.js pagina's geen false positives meer geven
- [ ] Verifieer dat bestaande monitoring issues correct gevonden worden (geen duplicaten)
- [ ] Controleer dat nieuwe issues correct aangemaakt worden wanneer er daadwerkelijke wijzigingen zijn