### PR TITLE
Fix Liferay timestamp regex voor &t= in query strings

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -97,8 +97,8 @@ def normalize_html(html: str) -> str:
     # Liferay CMS: authToken / p_auth CSRF token (verandert per request)
     html = re.sub(r"Liferay\.authToken\s*=\s*'[^']*'", "Liferay.authToken = 'TOKEN'", html)
     html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
-    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422)
-    html = re.sub(r"\?t=\d{10,15}", "?t=TIMESTAMP", html)
+    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422 of &t=...)
+    html = re.sub(r"[?&]t=\d{10,15}", "?t=TIMESTAMP", html)
     # Sentry tracing: trace-id en baggage veranderen per request
     html = re.sub(r'<meta\s+name="sentry-trace"[^>]*>', "", html)
     html = re.sub(r'<meta\s+name="baggage"\s+content="sentry-[^"]*"[^>]*>', "", html)


### PR DESCRIPTION
## Summary

- Fix `normalize_html` regex om ook `&t=` timestamps midden in Liferay combo query strings te matchen (naast `?t=` aan het begin)

De vorige fix (`?t=\d{10,15}`) ving alleen timestamps aan het begin van de query string op. Liferay combo URLs gebruiken `&t=` als extra parameter (bijv. `?browserId=other&t=1772370282388`), wat nog steeds false positives veroorzaakte op PDOK pagina's.

## Test plan

- [ ] Verify PDOK 3D pagina geen false positives meer triggert