### PR TITLE
Fix Liferay AUI module normalisatie voor PDOK false positives

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -99,6 +99,13 @@ def normalize_html(html: str) -> str:
     html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
     # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422 of &t=...)
     html = re.sub(r"[?&]t=\d{10,15}", "?t=TIMESTAMP", html)
+    # Liferay CMS: AUI module config blokken (variëren tussen backend servers)
+    html = re.sub(
+        r"<script[^>]*>\s*try\s*\{var MODULE_MAIN=.*?</script>",
+        "",
+        html,
+        flags=re.DOTALL,
+    )
     # Sentry tracing: trace-id en baggage veranderen per request
     html = re.sub(r'<meta\s+name="sentry-trace"[^>]*>', "", html)
     html = re.sub(r'<meta\s+name="baggage"\s+content="sentry-[^"]*"[^>]*>', "", html)


### PR DESCRIPTION
## Summary

- Strip Liferay `<script>` blokken met AUI module configuratie (`MODULE_MAIN`) die variëren tussen PDOK backend servers

PDOK draait Liferay met meerdere backend servers die verschillende sets AUI module definities retourneren. Dit veroorzaakte dat de body hash bij elke request kon verschillen, wat dagelijks false positive monitoring issues opleverde.

Getest: 8/8 opeenvolgende fetches van pdok.nl geven nu dezelfde hash.

## Test plan

- [x] Verified PDOK 3D pagina stabiel is over 8 fetches
- [ ] Verify monitoring draait zonder false positives