### PR TITLE
chore: update repo references after rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Changelog
 
-## [0.1.3](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
+## [0.1.3](https://github.com/developer-overheid-nl/skills-geo/compare/v0.1.2...v0.1.3) (2026-02-23)
 
 
 ### Opgelost
 
-* normaliseer Liferay CMS dynamische content om false positives te voorkomen ([#7](https://github.com/developer-overheid-nl/geo-plugin/issues/7)) ([cfee546](https://github.com/developer-overheid-nl/geo-plugin/commit/cfee546d6d6234046a7751bd8aa74400074905c0)), closes [#6](https://github.com/developer-overheid-nl/geo-plugin/issues/6)
+* normaliseer Liferay CMS dynamische content om false positives te voorkomen ([#7](https://github.com/developer-overheid-nl/skills-geo/issues/7)) ([cfee546](https://github.com/developer-overheid-nl/skills-geo/commit/cfee546d6d6234046a7751bd8aa74400074905c0)), closes [#6](https://github.com/developer-overheid-nl/skills-geo/issues/6)
 
-## [0.1.2](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
-
-
-### Opgelost
-
-* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/geo-plugin/issues/4)) ([c989785](https://github.com/developer-overheid-nl/geo-plugin/commit/c989785e598879c2b752fe265ea276044616fd0d))
-
-## [0.1.1](https://github.com/developer-overheid-nl/geo-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+## [0.1.2](https://github.com/developer-overheid-nl/skills-geo/compare/v0.1.1...v0.1.2) (2026-02-22)
 
 
 ### Opgelost
 
-* corrigeer PDOK tabel, Atom URL, repo namen en BGT governance ([96db6e3](https://github.com/developer-overheid-nl/geo-plugin/commit/96db6e3ca97deec87710e1e6a5a9ddde07a888b3))
+* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/skills-geo/issues/4)) ([c989785](https://github.com/developer-overheid-nl/skills-geo/commit/c989785e598879c2b752fe265ea276044616fd0d))
+
+## [0.1.1](https://github.com/developer-overheid-nl/skills-geo/compare/v0.1.0...v0.1.1) (2026-02-22)
+
+
+### Opgelost
+
+* corrigeer PDOK tabel, Atom URL, repo namen en BGT governance ([96db6e3](https://github.com/developer-overheid-nl/skills-geo/commit/96db6e3ca97deec87710e1e6a5a9ddde07a888b3))
 
 ## Changelog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Pre-commit hooks draaien automatisch ruff + markdownlint bij elke commit.
 
 ## Cross-references
 
-- `/geo-api` verwijst naar `/ls-api` (uit logius-standaarden-plugin) voor de ADR geo-module
+- `/geo-api` verwijst naar `/ls-api` (uit skills-standaarden) voor de ADR geo-module
 - `/ls-api` kan terugverwijzen naar `/geonovum` voor diepere geo-standaarden
 
 ## Plugin testen

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ```bash
 # Via de overheid-plugins marketplace (aanbevolen)
-claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/skills-marketplace
 claude plugin install geonovum@overheid-plugins
 
 # Per sessie
-git clone https://github.com/developer-overheid-nl/geo-plugin.git
-claude --plugin-dir ./geo-plugin
+git clone https://github.com/developer-overheid-nl/skills-geo.git
+claude --plugin-dir ./skills-geo
 ```
 
 ## Skills
@@ -46,7 +46,7 @@ De skills zijn gebaseerd op:
 
 ## Onderdeel van
 
-Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/developer-overheid-nl/overheid-claude-plugins) marketplace.
+Deze plugin is onderdeel van de [skills-marketplace](https://github.com/developer-overheid-nl/skills-marketplace) marketplace.
 
 ## Disclaimer
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -43,8 +43,8 @@ maintenance:
   contacts:
     - name: developer-overheid-nl
   type: community
-name: geo-plugin
+name: skills-geo
 releaseDate: '2026-02-22'
 softwareVersion: 0.1.3
 softwareType: standalone/other
-url: https://github.com/developer-overheid-nl/geo-plugin
+url: https://github.com/developer-overheid-nl/skills-geo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "geo-plugin"
+name = "skills-geo"
 version = "0.1.3"
 description = "Geonovum Claude Code Plugin - Geo-standaarden voor ruimtelijke data in Nederland"
 requires-python = ">=3.12"

--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -271,7 +271,7 @@ ogr2ogr -f "GeoJSON" /tmp/panden_wgs84.geojson \
 
 ## Cross-referenties
 
-- Gebruik `/ls-api` (uit logius-standaarden-plugin) voor de **ADR geo-module** — richtlijnen voor GeoJSON, CRS-negotiatie en bbox in REST APIs.
+- Gebruik `/ls-api` (uit skills-standaarden) voor de **ADR geo-module** — richtlijnen voor GeoJSON, CRS-negotiatie en bbox in REST APIs.
 - Gebruik `/geo-meta` voor metadata van services (ISO 19115, CSW).
 - Gebruik `/geo-inspire` voor INSPIRE-conforme view en download services.
 

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -111,4 +111,4 @@ gh api orgs/Geonovum/repos --paginate \
 | "Wat is NEN 3610?" | `/geo-model` |
 | "Hoe voldoe ik aan INSPIRE?" | `/geo-inspire` |
 | "Hoe werk ik met CityGML of 3D data?" | `/geo-3d` |
-| "Hoe gebruik ik de ADR geo-module?" | `/ls-api` (uit logius-standaarden-plugin) |
+| "Hoe gebruik ik de ADR geo-module?" | `/ls-api` (uit skills-standaarden) |


### PR DESCRIPTION
## Samenvatting

Update alle interne referenties na repo rename:
- `geo-plugin` → `skills-geo`
- `overheid-claude-plugins` → `skills-marketplace`
- `logius-standaarden-plugin` → `skills-standaarden` (cross-references)