### PR TITLE
Add plugin sync check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Valideer plugin.json
-        run: python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"
+        run: python3 -c "import json; json.load(open('.plugin/plugin.json'))"
+
+      - name: Controleer plugin sync
+        run: python3 scripts/generate_plugin.py --check
 
       - name: Controleer vereiste bestanden
         run: |
-          for f in LICENSE README.md CHANGELOG.md CLAUDE.md .claude-plugin/plugin.json; do
+          for f in LICENSE README.md CHANGELOG.md CLAUDE.md .plugin/plugin.json .claude-plugin/plugin.json .cursor-plugin/plugin.json; do
             if [ ! -f "$f" ]; then
               echo "FOUT: $f ontbreekt"
               exit 1


### PR DESCRIPTION
## Plugin sync check in CI

Voegt een CI-stap toe die controleert of `.claude-plugin/plugin.json` en
`.cursor-plugin/plugin.json` in sync zijn met `.plugin/plugin.json`.

Dit voorkomt dat platform-bestanden out-of-sync raken wanneer bijv. de
versie wordt gebumpt in `.plugin/plugin.json` zonder het generatiescript
te draaien.

Draait: `python3 scripts/generate_plugin.py --check`