### PR TITLE
Voeg licentiekolom toe aan Repositories-tabellen

### DIFF
--- a/skills/geo-3d/SKILL.md
+++ b/skills/geo-3d/SKILL.md
@@ -38,9 +38,9 @@ Nederland loopt voorop in 3D geo-informatie met de [3D Basisvoorziening](https:/
 
 ## Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## CityGML
 

--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -41,10 +41,10 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 ## Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services |
-| [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [MIT](https://opensource.org/licenses/MIT) |
+| [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [MIT](https://opensource.org/licenses/MIT) |
 
 ## WMS (Web Map Service)
 

--- a/skills/geo-inspire/SKILL.md
+++ b/skills/geo-inspire/SKILL.md
@@ -40,9 +40,9 @@ De [INSPIRE-richtlijn](https://inspire.ec.europa.eu/) (2007/2/EG) verplicht Euro
 
 ## Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## INSPIRE Data Thema's
 

--- a/skills/geo-meta/SKILL.md
+++ b/skills/geo-meta/SKILL.md
@@ -38,10 +38,10 @@ Metadata beschrijft geodata en -services zodat ze vindbaar, bruikbaar en beoorde
 
 ## Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel op ISO 19115 voor geografie |
-| [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Handreiking voor metadata |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel op ISO 19115 voor geografie | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Handreiking voor metadata | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## Nederlands Profiel ISO 19115
 

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -39,13 +39,13 @@ metadata:
 
 ## Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel |
-| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering |
-| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) |
-| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening |
-| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## NEN 3610 — Basismodel Geo-informatie
 

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -69,14 +69,14 @@ De geo-standaarden staan op de ['pas-toe-of-leg-uit'-lijst](https://www.forumsta
 
 ## Belangrijke Repositories
 
-| Repository | Beschrijving |
-|-----------|-------------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services |
-| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel |
-| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel ISO 19115 metadata |
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking |
-| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) |
-| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering |
+| Repository | Beschrijving | Licentie |
+|-----------|-------------|--------|
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [MIT](https://opensource.org/licenses/MIT) |
+| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel ISO 19115 metadata | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## Belangrijke Links
 

--- a/skills/geo/conflicts.md
+++ b/skills/geo/conflicts.md
@@ -1,0 +1,24 @@
+# Geonovum Geo-standaarden - Bronconflicten
+
+Geconstateerd: 2026-03-05
+
+## Ontbrekende licentie in GitHub-repositories
+
+De meeste Geonovum-repositories bevatten geen expliciet `LICENSE`-bestand in GitHub. De gepubliceerde standaarden op [docs.geostandaarden.nl](https://docs.geostandaarden.nl/) vermelden echter CC-BY-4.0 als licentie via de ReSpec-configuratie. Uitzondering is [ogc-checker](https://github.com/Geonovum/ogc-checker) dat een MIT-licentie heeft.
+
+| Repository | GitHub LICENSE | Gepubliceerde licentie | Status |
+|-----------|--------------|----------------------|--------|
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | MIT | N.v.t. (tooling) | OK |
+| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/imro](https://github.com/Geonovum/imro) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+
+### Aandachtspunt
+
+De licentie-informatie in de SKILL.md is gebaseerd op de gepubliceerde ReSpec-documenten. Het verdient aanbeveling dat de repositories expliciet een `LICENSE`-bestand toevoegen om juridische duidelijkheid te bieden, met name voor hergebruik onder artikel 15n Auteurswet (text and data mining exceptie).


### PR DESCRIPTION
## Summary

- Voegt een **Licentie** kolom toe aan alle Repositories-tabellen in de 6 SKILL.md bestanden
- ogc-checker = MIT, overige Geonovum repos = CC-BY-4.0 (via gepubliceerde ReSpec-documenten)
- Voegt `conflicts.md` toe voor het documenteren van ontbrekende LICENSE bestanden in GitHub

## Motivatie

Transparantie over licenties is relevant voor artikel 15n Auteurswet (text and data mining exceptie).

## Test plan

- [x] Alle bestaande tests passen (21 passed)
- [x] Markdown-tabellen correct geformatteerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)