### PR TITLE
Licentielinks naar officiële pagina's

### DIFF
--- a/skills/geo-3d/SKILL.md
+++ b/skills/geo-3d/SKILL.md
@@ -40,7 +40,7 @@ Nederland loopt voorop in 3D geo-informatie met de [3D Basisvoorziening](https:/
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM | CC-BY-4.0 |
+| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## CityGML
 

--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -43,8 +43,8 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [EUPL-1.2](https://github.com/Geonovum/ogc-checker/blob/main/LICENSE) |
-| [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://github.com/Geonovum/ogc-checker/blob/main/LICENSE) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
 

--- a/skills/geo-inspire/SKILL.md
+++ b/skills/geo-inspire/SKILL.md
@@ -42,7 +42,7 @@ De [INSPIRE-richtlijn](https://inspire.ec.europa.eu/) (2007/2/EG) verplicht Euro
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking | CC-BY-4.0 |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## INSPIRE Data Thema's
 

--- a/skills/geo-meta/SKILL.md
+++ b/skills/geo-meta/SKILL.md
@@ -40,8 +40,8 @@ Metadata beschrijft geodata en -services zodat ze vindbaar, bruikbaar en beoorde
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel op ISO 19115 voor geografie | CC-BY-4.0 |
-| [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Handreiking voor metadata | CC-BY-4.0 |
+| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel op ISO 19115 voor geografie | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Handreiking voor metadata | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## Nederlands Profiel ISO 19115
 

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -41,11 +41,11 @@ metadata:
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | CC-BY-4.0 |
-| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | CC-BY-4.0 |
-| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | CC-BY-4.0 |
-| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | CC-BY-4.0 |
-| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | CC-BY-4.0 |
+| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## NEN 3610 — Basismodel Geo-informatie
 

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -71,12 +71,12 @@ De geo-standaarden staan op de ['pas-toe-of-leg-uit'-lijst](https://www.forumsta
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [EUPL-1.2](https://github.com/Geonovum/ogc-checker/blob/main/LICENSE) |
-| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | CC-BY-4.0 |
-| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel ISO 19115 metadata | CC-BY-4.0 |
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking | CC-BY-4.0 |
-| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | CC-BY-4.0 |
-| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | CC-BY-4.0 |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel ISO 19115 metadata | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## Belangrijke Links
 


### PR DESCRIPTION
## Summary

- Alle licentie-entries in SKILL.md tabellen linken nu naar **officiële licentiepagina's** (niet meer naar GitHub LICENSE-bestanden)
- CC-BY-4.0 → creativecommons.org/licenses/by/4.0/legalcode.en
- EUPL-1.2 (ogc-checker) → eupl.eu/1.2/en

## Test plan

- [x] `uv run pytest` passes (60 tests)
- [x] Geen GitHub LICENSE links meer in licentiekolommen