### PR TITLE
Fix licenties inspire-handreiking en imro naar CC-BY-ND-4.0

### DIFF
--- a/skills/geo-inspire/SKILL.md
+++ b/skills/geo-inspire/SKILL.md
@@ -42,7 +42,7 @@ De [INSPIRE-richtlijn](https://inspire.ec.europa.eu/) (2007/2/EG) verplicht Euro
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Nederlandse INSPIRE implementatie handreiking | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode.en) |
 
 ## INSPIRE Data Thema's
 

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -44,7 +44,7 @@ metadata:
 | [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
-| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode.en) |
 | [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## NEN 3610 — Basismodel Geo-informatie

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -74,7 +74,7 @@ De geo-standaarden staan op de ['pas-toe-of-leg-uit'-lijst](https://www.forumsta
 | [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | NEN 3610 linked data profiel | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Nederlands profiel ISO 19115 metadata | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | INSPIRE implementatie handreiking | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode.en) |
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 

--- a/skills/geo/conflicts.md
+++ b/skills/geo/conflicts.md
@@ -4,19 +4,19 @@ Geconstateerd: 2026-03-05
 
 ## Ontbrekende licentie in GitHub-repositories
 
-De meeste Geonovum-repositories bevatten geen expliciet `LICENSE`-bestand in GitHub. De gepubliceerde standaarden op [docs.geostandaarden.nl](https://docs.geostandaarden.nl/) vermelden echter CC-BY-4.0 als licentie via de ReSpec-configuratie. Uitzondering is [ogc-checker](https://github.com/Geonovum/ogc-checker) dat een EUPL-1.2-licentie heeft.
+De meeste Geonovum-repositories bevatten geen expliciet `LICENSE`-bestand in GitHub. De gepubliceerde standaarden op [docs.geostandaarden.nl](https://docs.geostandaarden.nl/) vermelden een Creative Commons-licentie via de ReSpec-configuratie. De meeste standaarden gebruiken CC-BY-4.0, maar sommige (zoals inspire-handreiking en imro) gebruiken CC-BY-ND-4.0. Uitzondering is [ogc-checker](https://github.com/Geonovum/ogc-checker) dat een EUPL-1.2-licentie heeft.
 
 | Repository | GitHub LICENSE | Gepubliceerde licentie | Status |
 |-----------|--------------|----------------------|--------|
 | [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | EUPL-1.2 | N.v.t. (tooling) | OK |
 | [Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
-| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Geen | CC-BY-ND-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
-| [Geonovum/imro](https://github.com/Geonovum/imro) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/imro](https://github.com/Geonovum/imro) | Geen | CC-BY-ND-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/imkl](https://github.com/Geonovum/imkl) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 
 ### Aandachtspunt


### PR DESCRIPTION
## Summary

- Corrigeer licentie van `inspire-handreiking` en `imro` van CC-BY-4.0 naar **CC-BY-ND-4.0**
- De ReSpec-configuratie in beide upstream repos specificeert `license: 'cc-by-nd'`, wat CC-BY-ND-4.0 betekent (geen afgeleide werken toegestaan)
- Update `conflicts.md` met de correcte licentie-informatie

## Gewijzigde bestanden

- `skills/geo/SKILL.md` — inspire-handreiking licentie gecorrigeerd
- `skills/geo-inspire/SKILL.md` — inspire-handreiking licentie gecorrigeerd
- `skills/geo-model/SKILL.md` — imro licentie gecorrigeerd
- `skills/geo/conflicts.md` — inleidende tekst en tabelrijen aangepast

## Test plan

- [ ] Controleer dat de licentielinks werken (CC-BY-ND-4.0 legalcode pagina)
- [ ] Verify dat de conflicts.md tabel consistent is met de SKILL.md bestanden