### PR TITLE
Fix incorrect license claims for GeoBIM and imkl

### DIFF
--- a/skills/geo-3d/SKILL.md
+++ b/skills/geo-3d/SKILL.md
@@ -40,7 +40,7 @@ Nederland loopt voorop in 3D geo-informatie met de [3D Basisvoorziening](https:/
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Integratie van GIS en BIM | Niet gespecificeerd |
 
 ## CityGML
 

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -45,7 +45,7 @@ metadata:
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/imro](https://github.com/Geonovum/imro) | Informatiemodel Ruimtelijke Ordening | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode.en) |
-| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
+| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Informatiemodel Kabels en Leidingen | Niet gespecificeerd |
 
 ## NEN 3610 — Basismodel Geo-informatie
 

--- a/skills/geo/conflicts.md
+++ b/skills/geo/conflicts.md
@@ -14,10 +14,10 @@ De meeste Geonovum-repositories bevatten geen expliciet `LICENSE`-bestand in Git
 | [Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking) | Geen | CC-BY-ND-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
-| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM) | Geen | Geen (geen ReSpec config aanwezig) | Niet gespecificeerd |
 | [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [Geonovum/imro](https://github.com/Geonovum/imro) | Geen | CC-BY-ND-4.0 (ReSpec) | Discrepantie |
-| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [Geonovum/imkl](https://github.com/Geonovum/imkl) | Geen | Geen (geen ReSpec config aanwezig) | Niet gespecificeerd |
 
 ### Aandachtspunt
 


### PR DESCRIPTION
## Summary
- GeoBIM repo: changed license from CC-BY-4.0 to "Niet gespecificeerd" — the repo has no LICENSE file and no ReSpec config
- imkl repo: changed license from CC-BY-4.0 to "Niet gespecificeerd" — the repo has no LICENSE file and no ReSpec config with license field
- Updated conflicts.md to reflect the actual status

## Context
Full audit of all upstream repo licenses verified against actual ReSpec configs and LICENSE files. These two repos were the only ones where a license was claimed that could not be verified from any source.