### PR TITLE
Fix: sync plugin.json source of truth with release-please

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "geo",
   "displayName": "Geo",
   "description": "Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-  "version": "0.1.3"
+  "version": "0.2.0"
 }

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "geo",
   "description": "Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-  "version": "0.1.3"
+  "version": "0.2.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": ".claude-plugin/plugin.json",
+          "path": ".plugin/plugin.json",
           "jsonpath": "$.version"
         },
         {

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "skills-geo"
-version = "0.1.3"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary
- Release-please was bumping `.claude-plugin/plugin.json` directly, but `.plugin/plugin.json` is the source of truth for `generate_plugin.py`
- This caused CI to fail on the v0.2.0 release because the generated files were out of sync
- Now release-please bumps `.plugin/plugin.json` instead, and platform files are generated from it

## Changes
- `release-please-config.json`: point extra-files at `.plugin/plugin.json`
- `.plugin/plugin.json`: bump to 0.2.0
- Regenerated `.cursor-plugin/plugin.json`