### PR TITLE
Beperk CC-BY-ND content tot verwijzingen

### DIFF
--- a/skills/geo-inspire/SKILL.md
+++ b/skills/geo-inspire/SKILL.md
@@ -213,11 +213,7 @@ curl -s "https://inspire.ec.europa.eu/validator/v2/TestRuns/{testRunId}" \
 
 ### Geonovum Handreiking
 
-De [INSPIRE handreiking](https://docs.geostandaarden.nl/eu/INSPIRE-handreiking/) van Geonovum beschrijft:
-- Hoe Nederlandse organisaties moeten voldoen aan INSPIRE
-- Welke datasets als INSPIRE-plichtig zijn aangemerkt
-- Hoe view/download/discovery services ingericht moeten worden
-- Hoe data getransformeerd moet worden naar INSPIRE-datamodellen
+Voor de Nederlandse INSPIRE-implementatie biedt Geonovum de [INSPIRE handreiking](https://docs.geostandaarden.nl/eu/INSPIRE-handreiking/) aan. Raadpleeg deze handreiking voor details over INSPIRE-verplichtingen, datasets en implementatie-eisen. De handreiking heeft een CC-BY-ND-4.0 licentie; de inhoud wordt hier niet samengevat.
 
 ### Monitoring en Rapportage
 

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -34,7 +34,7 @@ metadata:
 | MIM 1.2 | Metamodel | Regels voor het opstellen van informatiemodellen | Aanbevolen |
 | IMGeo 2.2 / BGT | Sectormodel | Grootschalige topografie | Verplicht (als sectormodel) |
 | IMBAG | Sectormodel | Adressen en gebouwen | Verplicht (als sectormodel) |
-| IMRO | Sectormodel | Ruimtelijke ordening | Verplicht (als sectormodel) |
+| IMRO | Sectormodel | Ruimtelijke ordening (CC-BY-ND-4.0; raadpleeg [officiële bron](https://docs.geostandaarden.nl/ro/imro/)) | Verplicht (als sectormodel) |
 | IMKL | Sectormodel | Kabels en leidingen | Verplicht (als sectormodel) |
 
 ## Repositories


### PR DESCRIPTION
## Summary

- **geo-inspire/SKILL.md**: Samenvatting van de INSPIRE handreiking (4 bullets) vervangen door alleen een verwijzing met CC-BY-ND-4.0 opmerking
- **geo-model/SKILL.md**: IMRO-rij in standaardentabel aangevuld met CC-BY-ND-4.0 vermelding en link naar officiële bron

De INSPIRE handreiking (`Geonovum/inspire-handreiking`) en IMRO (`Geonovum/imro`) hebben een CC-BY-ND-4.0 licentie die afgeleide werken verbiedt. De eerdere samenvattende bullets waren een afgeleid werk; nu wordt alleen verwezen naar de bronnen.

## Test plan

- [ ] Controleer dat geo-inspire/SKILL.md geen samenvattingen van de handreiking meer bevat
- [ ] Controleer dat geo-model/SKILL.md een CC-BY-ND opmerking bij IMRO heeft
- [ ] Controleer dat alle overige content (technische voorbeelden, thematabellen, validatie-info) intact is