### PR TITLE
fix: normaliseer opeenvolgende lege regels in normalize_html

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -137,6 +137,8 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
     # Next.js/React escaped JSON nonces: \"nonce\":\"base64value\"
     html = re.sub(r'\\"nonce\\":\\"[^"\\]*\\"', r'\\"nonce\\":\\"NONCE\\"', html)
+    # Normaliseer opeenvolgende lege regels (variëren tussen requests bij sommige CMS'en)
+    html = re.sub(r"\n{3,}", "\n\n", html)
     return html
 
 


### PR DESCRIPTION
Fix false positive monitoring issues veroorzaakt door wisselende aantallen lege regels
in Liferay CMS responses (bijv. PDOK 3D basisvoorziening pagina).

Voegt `re.sub(r"\n{3,}", "\n\n", html)` toe aan het eind van `normalize_html()`.

Sluit #79.