### PR TITLE
fix: update geo-3d en geo skills na content-wijzigingen

### DIFF
--- a/skills/geo-3d/SKILL.md
+++ b/skills/geo-3d/SKILL.md
@@ -175,9 +175,11 @@ tileset.json          ← Hoofdbestand (metadata + boomstructuur)
 
 ### 3D Basisvoorziening via PDOK
 
-De [3D Basisvoorziening](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1) is het landsdekkende 3D-model van Nederland, beschikbaar via PDOK als 8 collecties. Brondata: BAG, BGT en AHN (4, 5 en 6). Licentie: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.nl) (data: Kadaster). Zie ook de [productbeschrijving](https://3d.kadaster.nl/productbeschrijving/) en de [PDOK 3D Viewer](https://app.pdok.nl/3d-viewer).
+De [3D Basisvoorziening](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1) is het landsdekkende 3D-model van Nederland, beschikbaar via PDOK als 8 collecties. Brondata: BAG, BGT en AHN (4, 5 en 6). Licentie: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.nl) (data: Kadaster). Ontwikkeld door het Kadaster in samenwerking met het ministerie van VRO en de TU Delft. Zie ook de [productbeschrijving](https://3d.kadaster.nl/productbeschrijving/) en de [PDOK 3D Viewer](https://app.pdok.nl/3d-viewer).
 
-Beschikbare formaten: OGC 3D Tiles (gebouwen, terreinen), CityJSON (3D objecten), GeoPackage (hoogte-attributen), Quantized Mesh (DTM), LASZip (DSM). Zie [reference.md](reference.md) voor de volledige collectie-tabel.
+Beschikbare formaten: OGC 3D Tiles (gebouwen, terreinen), CityJSON (3D objecten, met IFC converter voor BIM-software), GeoPackage (hoogte-attributen), Quantized Mesh (DTM), LASZip (DSM). Data is beschikbaar via OGC API 3D GeoVolumes en OGC API Features. Zie [reference.md](reference.md) voor de volledige collectie-tabel.
+
+Toepassingen: geluidsmodellering, schaduwanalyse, zonnepotentie, waterafvoerberekeningen, Omgevingswet-plannen en burgercommunicatie. Fouten melden kan via [Verbeter de Kaart](https://verbeterdekaart.nl), recente meldingen staan in de dataset "3D Terugmeldingen". Vragen? Zie [Geoforum.nl](https://geoforum.nl) (categorie datasets/3d).
 
 ```bash
 # Alle collecties ophalen

--- a/skills/geo-3d/reference.md
+++ b/skills/geo-3d/reference.md
@@ -68,12 +68,12 @@ De Nederlandse 3D Basisvoorziening biedt 8 collecties via de OGC API op PDOK. Br
 |-----------|---------|------|-------------|
 | 3D Tiles Gebouwen | OGC 3D Tiles | BAG + AHN | Gebouwen LOD 2.2 (fallback LOD 1.3) voor visualisatie |
 | 3D Tiles Terreinen | OGC 3D Tiles | BGT + AHN | Terreinen, wegen en water op maaiveldniveau |
-| 3D Objecten Gebouwen | CityJSON | BAG + AHN | Gebouwen LOD 2.2 voor analyse in GIS/BIM |
+| 3D Objecten Gebouwen | CityJSON | BAG + AHN | Gebouwen LOD 2.2 voor analyse in GIS/BIM (IFC converter beschikbaar voor BIM-software) |
 | 3D Objecten Gebouwen en Terreinen | CityJSON | BAG + BGT + AHN | Gebouwen + terreinen + water + wegen voor analyse |
 | 2D Objecten Gebouwen met hoogte | GeoPackage | BAG + AHN | 2D geometrie met hoogte-attributen per pand |
 | Digitaal Terreinmodel (DTM) | Quantized Mesh | AHN | Geïnterpoleerd maaiveld-terreinmodel |
-| DSM 20 cm | LASZip | Luchtfoto's | Oppervlaktemodel incl. objecten en vegetatie (20 cm) |
-| DSM 8 cm | LASZip | Luchtfoto's | Hoge-resolutie oppervlaktemodel (8 cm) |
+| DSM 20 cm | LASZip | Puntenwolken uit luchtfoto's | Oppervlaktemodel incl. objecten en vegetatie (20 cm) |
+| DSM 8 cm | LASZip | Puntenwolken uit luchtfoto's | Hoge-resolutie oppervlaktemodel (8 cm) |
 
 ## 3D Tiles Specificatie
 

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -78,6 +78,17 @@ De geo-standaarden staan op de ['pas-toe-of-leg-uit'-lijst](https://www.forumsta
 | [Geonovum/IMGeo](https://github.com/Geonovum/IMGeo) | Informatiemodel Geografie (BGT/IMGeo) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving) | Metamodel Informatie Modellering | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
+## Aanvullende Standaarden
+
+Naast de domein-skills hierboven beheert Geonovum ook:
+
+| Standaard | Beschrijving |
+|-----------|-------------|
+| [Raamwerk Geo-Standaarden](https://docs.geostandaarden.nl/raamwerk/def-hr-raamwerk-20250109/) | Overzichtsdocument: hoe alle geo-standaarden samenhangen |
+| [GeoPackage](https://www.geonovum.nl/geo-standaarden/geopackage) | Verplicht formaat voor geodata-downloads bij de overheid (sinds 2019) |
+| [NL-SBB](https://docs.geostandaarden.nl/nl-sbb/def-st-nl-sbb-20230614/) | Standaard voor het beschrijven van begrippen |
+| [IMX-Geo](https://geonovum.github.io/IMX-Geo/) | Semantisch model voor samenhang basis-/kernregistraties (Kadaster + Geonovum) |
+
 ## Belangrijke Links
 
 - **Gepubliceerde standaarden:** [docs.geostandaarden.nl](https://docs.geostandaarden.nl/)


### PR DESCRIPTION
## Samenvatting

Updates na echte content-wijzigingen op pdok.nl (3D Basisvoorziening) en geonovum.nl/geo-standaarden.

**geo-3d:**
- IFC converter voor 3D Objecten Gebouwen (CityJSON → BIM)
- OGC API 3D GeoVolumes en OGC API Features als API-types
- Verbeterdekaart.nl en Geoforum.nl als community-links
- Toepassingen: geluidsmodellering, schaduwanalyse, zonnepotentie, waterafvoer
- TU Delft en ministerie VRO als samenwerkingspartners
- DSM brondata verduidelijkt (puntenwolken uit luchtfoto's)

**geo (overzicht):**
- Raamwerk Geo-Standaarden als overzichtsdocument
- GeoPackage als verplicht downloadformaat (sinds 2019)
- NL-SBB en IMX-Geo als aanvullende standaarden

Sluit #103, sluit #104