### PR TITLE
feat(geo-meta): MDTO-samenhang en SHACL-validatie

### DIFF
--- a/skills/geo-meta/SKILL.md
+++ b/skills/geo-meta/SKILL.md
@@ -5,7 +5,9 @@ description: >-
   vraagt over 'metadata', 'ISO 19115', 'ISO 19119', 'CSW',
   'NGR', 'nationaal georegister', 'Nationaal Georegister',
   'DCAT geo', 'metadata profiel', 'metadata publiceren',
-  'metadata validatie', 'geodata catalogus', 'discovery service'.
+  'metadata validatie', 'geodata catalogus', 'discovery service',
+  'MDTO', 'metagegevens duurzaam toegankelijke overheidsinformatie',
+  'SHACL', 'DCAT validatie', 'DCAT-AP-NL'.
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -34,7 +36,8 @@ Metadata beschrijft geodata en -services zodat ze vindbaar, bruikbaar en beoorde
 | ISO 19119:2005 | Metadata | Beschrijving van services | Verplicht |
 | NL profiel ISO 19115 | Profiel | Nederlandse invulling van ISO 19115 | Verplicht |
 | CSW 2.0.2 | Protocol | Catalogue Service for the Web — zoeken/harvesten | Geen eigen Forum status |
-| DCAT | Vocabulaire | Data Catalog Vocabulary, geo-extensie | Aanbevolen |
+| DCAT-AP-NL | Vocabulaire | Data Catalog Vocabulary, geo-extensie via GeoDCAT-AP | Aanbevolen |
+| MDTO | Metadata | Metagegevens Duurzaam Toegankelijke Overheidsinformatie (Nationaal Archief) | Gerelateerd |
 
 ## Repositories
 
@@ -199,7 +202,19 @@ for rec_id, rec in csw.records.items():
 
 ## DCAT voor Geodata
 
-DCAT (Data Catalog Vocabulary) wordt steeds meer gebruikt naast ISO 19115. Het profiel GeoDCAT-AP biedt een mapping van ISO 19115 naar DCAT.
+DCAT (Data Catalog Vocabulary) wordt steeds meer gebruikt naast ISO 19115. Het profiel GeoDCAT-AP biedt een mapping van ISO 19115 naar DCAT. DCAT-AP-NL is het Nederlandse profiel op DCAT-AP.
+
+### Samenhang metadata standaarden
+
+Er zijn drie metadata-standaarden die elk een eigen perspectief hebben:
+
+| Standaard | Focus | Formaat | Doelgroep |
+|-----------|-------|---------|-----------|
+| ISO 19115/19119 | Geo-datasets en -services | XML | Geo-domein (NGR, INSPIRE) |
+| DCAT-AP-NL | Datacatalogi, linked data | RDF | Data.overheid.nl, Europees dataportaal |
+| MDTO | Duurzame toegankelijkheid overheidsinformatie | XML | Archivering (Archiefwet, Woo) |
+
+Belangrijke verschillen: MDTO gaat uit van informatie-objecten en bestanden, terwijl DCAT en ISO 19115 werken met datasets en distributies. Meer informatie over de samenhang staat in de [Geonovum notitie over relaties metadata standaarden](https://www.geonovum.nl/geo-standaarden/metadataprofiel-dcat-ap-nl/relaties-verschillende-metadata-standaarden).
 
 ### Verhouding ISO 19115 en DCAT
 

--- a/skills/geo-meta/reference.md
+++ b/skills/geo-meta/reference.md
@@ -93,6 +93,8 @@ Het metadata-record moet voldoen aan het ISO 19115 XML-schema (gmd namespace). C
 
 ### Validatietools
 
+#### ISO XML metadata
+
 ```bash
 # Metadata valideren via de Geonovum validator
 curl -s -X POST "https://validatie.geostandaarden.nl/etf-webapp/v2/TestRuns" \
@@ -102,6 +104,34 @@ curl -s -X POST "https://validatie.geostandaarden.nl/etf-webapp/v2/TestRuns" \
 # XML-schema validatie met xmllint
 xmllint --schema http://www.isotc211.org/2005/gmd/gmd.xsd metadata.xml --noout
 ```
+
+#### DCAT metadata (SHACL-validatie)
+
+DCAT-AP profielen worden gedefinieerd in SHACL. DCAT-AP-NL bouwt voort op de SHACL-shapes van DCAT-AP met aanvullende Nederlandse regels. Er zijn meerdere validatieniveaus: alleen verplichte eigenschappen, aanbevolen eigenschappen, of inclusief HVD-eisen (High-Value Datasets).
+
+**Online validator (Europa):**
+De [DCAT-AP online validator](https://www.itb.ec.europa.eu/shacl/semic-shacl/upload) ondersteunt verschillende versies en niveaus van DCAT-AP.
+
+**Python (pyshacl):**
+```python
+# Voorbeeld: DCAT-AP-NL metadata valideren met pyshacl
+# Gebaseerd op: https://github.com/Geonovum/ISO-2-DCAT/blob/main/dcat-ap-nl-3/dcat-ap-nl-shacl-validatie/test.ipynb
+from pyshacl import validate
+from rdflib import Graph
+
+data_graph = Graph().parse("metadata.ttl")
+shacl_graph = Graph().parse("dcat-ap-nl-shapes.ttl")
+
+conforms, results_graph, results_text = validate(
+    data_graph,
+    shacl_graph=shacl_graph,
+    inference="rdfs",
+    abort_on_first=False
+)
+print(results_text)
+```
+
+Let op: DCAT metadata maakt vaak gebruik van URI's naar externe registraties (zoals TOOI URI's voor overheidsorganisaties). Bij validatie is het niet altijd mogelijk om te controleren of externe URI-verwijzingen correct zijn zonder deze daadwerkelijk te volgen.
 
 ## NGR Publicatieworkflow
 


### PR DESCRIPTION
## Samenvatting

De geo-meta skill miste informatie over MDTO en SHACL-validatie voor DCAT metadata.

De upstream [Geonovum/Metadata-handreiking](https://github.com/Geonovum/Metadata-handreiking) heeft deze content al op 9 maart toegevoegd (PR #2, `std-372`). Monitoring issue #119 pikte dit pas op door een kleine follow-up commit op 26 maart (afbeelding + TBD-link vervangen door echte URL).

### Wijzigingen

**SKILL.md:**
- Samenhangstabel MDTO / DCAT-AP-NL / ISO 19115 (focus, formaat, doelgroep)
- Link naar [Geonovum notitie over relaties metadata standaarden](https://www.geonovum.nl/geo-standaarden/metadataprofiel-dcat-ap-nl/relaties-verschillende-metadata-standaarden)
- MDTO, SHACL, DCAT-AP-NL als triggers in skill description

**reference.md:**
- SHACL-validatie sectie: DCAT-AP online validator (Europa) en pyshacl voorbeeld
- Waarschuwing over externe URI-verwijzingen bij validatie

### Bronverificatie

Alle content geverifieerd tegen:
- [Upstream handreiking 2-stelsel.md](https://github.com/Geonovum/Metadata-handreiking/blob/main/2-stelsel.md) — MDTO-paragraaf (sinds 9 maart)
- [Upstream handreiking 4-werkproces.md](https://github.com/Geonovum/Metadata-handreiking/blob/main/4-werkproces.md) — SHACL-validatie (sinds 9 maart)
- [Geonovum notitie relaties metadata standaarden](https://www.geonovum.nl/geo-standaarden/metadataprofiel-dcat-ap-nl/relaties-verschillende-metadata-standaarden) — samenhang drie standaarden
- [pyshacl validatie notebook](https://github.com/Geonovum/ISO-2-DCAT/blob/main/dcat-ap-nl-3/dcat-ap-nl-shacl-validatie/test.ipynb) — code geverifieerd tegen notebook

Sluit #119.