### PR TITLE
fix: update ogc-checker versie en normalize_html Apache timestamps

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -163,6 +163,8 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
     # Next.js/React escaped JSON nonces: \"nonce\":\"base64value\"
     html = re.sub(r'\\"nonce\\":\\"[^"\\]*\\"', r'\\"nonce\\":\\"NONCE\\"', html)
+    # Apache directory listings: timestamps variëren bij server-deployments
+    html = re.sub(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s+", "", html)
     # Normaliseer opeenvolgende lege regels (variëren tussen requests bij sommige CMS'en)
     html = re.sub(r"\n{3,}", "\n\n", html)
     return html

--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -43,7 +43,7 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.0) | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.1) | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
@@ -230,7 +230,7 @@ print(f"Gevonden: {len(data['features'])} panden")
 
 ## ogc-checker Validatie
 
-De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.0) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
+De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.1) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
 
 ```bash
 # Repo-informatie ophalen


### PR DESCRIPTION
## Summary

- ogc-checker versiereferentie v1.0.0 naar v1.0.1 in geo-api SKILL.md (2 plekken), conform [upstream release](https://github.com/Geonovum/ogc-checker/releases/tag/v1.0.1)
- `normalize_html`: Apache directory listing timestamps strippen (voorkomt false positives bij docs.geostandaarden.nl)

## Test plan

- [ ] CI checks groen
- [ ] `uv run python -m pytest -v` lokaal groen (65 passed)

Sluit monitoring issues #128 #129 #130 #131 #132 #133