### PR TITLE
fix: update ogc-checker version reference to v1.0.4

### DIFF
--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -43,7 +43,7 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.1) | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.4) | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
@@ -230,7 +230,7 @@ print(f"Gevonden: {len(data['features'])} panden")
 
 ## ogc-checker Validatie
 
-De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.1) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
+De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.4) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
 
 ```bash
 # Repo-informatie ophalen


### PR DESCRIPTION
## Samenvatting

Update ogc-checker versie-referenties in `skills/geo-api/SKILL.md` van v1.0.1 naar v1.0.4.

Wijzigingen tussen v1.0.1 en v1.0.4 (29 commits): voornamelijk dependabot bumps, plus upgrade van `standards-checker` naar v1.1.4. Geen wijzigingen die een herziening van de skill-content vereisen — alleen de versie-referentie.

Closes #194.