### PR TITLE
fix: kort skill descriptions in om listing budget te ontlasten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Achtergrondkennis die niet direct nodig is voor code-generatie wordt verplaatst 
 - Exploratie commando's (`gh api`, `curl`, `ogr2ogr`)
 
 ### Description triggers
-Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd.
+Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd. Houd descriptions kort: doel **~150 chars, max 200**. Eén functionele zin met de eigennamen die mensen daadwerkelijk gebruiken (NEN 3610, OGC API, INSPIRE, MDTO) is genoeg; voeg alleen een korte triggerstaart toe voor termen die niet uit de hoofdzin volgen. Geen "Gebruik deze skill wanneer..."-aanhef en geen quoted keyword-lijsten — die vreten skill listing budget op zonder triggerwaarde toe te voegen.
 
 ### Allowed tools
 Standaard set:

--- a/skills/geo-3d/SKILL.md
+++ b/skills/geo-3d/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: geo-3d
-description: >-
-  3D standaarden voor ruimtelijke data. Gebruik deze skill wanneer de
-  gebruiker vraagt over '3D', 'CityGML', '3D tiling', '3D Tiles',
-  'GeoBIM', 'digital twin', '3D geo', '3D standaarden',
-  '3D basisvoorziening', 'BIM GIS', 'IFC', 'LOD', 'level of detail',
-  '3D stadsmodel', 'Cesium', '3D visualisatie geo'.
+description: "3D-standaarden voor ruimtelijke data: CityGML, 3D Tiles, GeoBIM, IFC, LOD (level of detail), Cesium. Ook 3D basisvoorziening en digital twin."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: geo-api
-description: >-
-  OGC API services en kaartdiensten. Gebruik deze skill wanneer de gebruiker
-  vraagt over 'OGC API', 'WMS', 'WFS', 'WCS', 'WMTS',
-  'OGC API Features', 'kaartdienst', 'map service', 'ogc-checker',
-  'geo API', 'GetCapabilities', 'GetMap', 'GetFeature',
-  'PDOK service', 'geo webservice', 'spatial web service'.
+description: "OGC API services en kaartdiensten: WMS, WFS, WCS, WMTS, OGC API Features. PDOK-services, GetCapabilities/GetMap/GetFeature, ogc-checker validatie."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/geo-inspire/SKILL.md
+++ b/skills/geo-inspire/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: geo-inspire
-description: >-
-  INSPIRE Europese richtlijn voor geodata. Gebruik deze skill wanneer de
-  gebruiker vraagt over 'INSPIRE', 'INSPIRE validator', 'ETF',
-  'Europese richtlijn geo', 'INSPIRE implementatie',
-  'INSPIRE datathema', 'INSPIRE download service',
-  'INSPIRE view service', 'INSPIRE discovery', 'INSPIRE handreiking',
-  'Annex I', 'Annex II', 'Annex III'.
+description: "INSPIRE Europese richtlijn voor geodata: download/view/discovery services, ETF-validator, Annex I/II/III datathema's, implementatie-handreikingen."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/geo-meta/SKILL.md
+++ b/skills/geo-meta/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: geo-meta
-description: >-
-  Metadata standaarden voor geodata. Gebruik deze skill wanneer de gebruiker
-  vraagt over 'metadata', 'ISO 19115', 'ISO 19119', 'CSW',
-  'NGR', 'nationaal georegister', 'Nationaal Georegister',
-  'DCAT geo', 'metadata profiel', 'metadata publiceren',
-  'metadata validatie', 'geodata catalogus', 'discovery service',
-  'MDTO', 'metagegevens duurzaam toegankelijke overheidsinformatie',
-  'SHACL', 'DCAT validatie', 'DCAT-AP-NL'.
+description: "Metadata voor geodata: ISO 19115/19119, CSW, NGR (Nationaal Georegister), DCAT-AP-NL, MDTO, SHACL-validatie. Metadata publiceren en geodata-catalogi."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/geo-model/SKILL.md
+++ b/skills/geo-model/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: geo-model
-description: >-
-  Informatiemodellen voor geodata. Gebruik deze skill wanneer de gebruiker
-  vraagt over 'NEN 3610', 'MIM', 'IMGeo', 'IMBAG', 'IMRO', 'IMKL',
-  'informatiemodel', 'BGT', 'basismodel geo-informatie',
-  'linked data geo', 'sectormodel', 'metamodel informatie modellering',
-  'geo-informatiemodel', 'UML geo'.
+description: "Informatiemodellen voor geodata: NEN 3610, MIM, IMGeo, IMBAG, IMRO, IMKL, BGT. Linked data geo, UML, metamodel informatiemodellering."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/geo/SKILL.md
+++ b/skills/geo/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: geo
-description: >-
-  Overzicht van alle Geonovum geo-standaarden. Gebruik deze skill wanneer de
-  gebruiker vraagt over 'geonovum', 'geo standaarden', 'geostandaarden',
-  'PDOK', 'ruimtelijke data', 'spatial data', 'GIS overheid',
-  'welke geo-standaarden zijn er', 'geo-informatie Nederland',
-  'geodata overheid'.
+description: "Overzicht Geonovum geo-standaarden voor de Nederlandse overheid. Routeert naar geo-api, geo-meta, geo-model, geo-3d, geo-inspire. Ook PDOK en GIS-vragen."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)


### PR DESCRIPTION
## Probleem

Per `developer-overheid-nl/skills-marketplace#61` melden gebruikers dat onze plugin descriptions zoveel skill listing budget vreten dat in gemengde sessies skills uit de listing vallen ("60 descriptions dropped, 3.1%/1% of context").

Onze 6 geo-skills gingen tot 415 chars (`geo-meta`), gemiddeld 323 chars. Het patroon was vrijwel altijd `Gebruik deze skill wanneer de gebruiker vraagt over 'X', 'Y', 'Z', ...` met 10-20 quoted keywords. Die aanhef en quotes voegen geen triggerwaarde toe.

## Wat verandert

Per skill: één Nederlandse functionele zin met de eigennamen die mensen daadwerkelijk gebruiken, eventueel een korte triggerstaart. Doel ~150 chars, max 200.

Niet-afleidbare jargon blijft expliciet:
- `geo-api`: WMS, WFS, WCS, WMTS, OGC API Features, GetCapabilities/GetMap/GetFeature, ogc-checker
- `geo-meta`: ISO 19115/19119, CSW, NGR, DCAT-AP-NL, MDTO, SHACL
- `geo-model`: NEN 3610, MIM, IMGeo, IMBAG, IMRO, IMKL, BGT
- `geo-3d`: CityGML, 3D Tiles, GeoBIM, IFC, LOD, Cesium
- `geo-inspire`: ETF-validator, Annex I/II/III

Synoniemen die het model semantisch dekt zijn weg ('NGR' + 'nationaal georegister' + 'Nationaal Georegister' werd één keer "NGR (Nationaal Georegister)").

## Resultaat

| Skill | Was | Nu |
|---|---:|---:|
| `geo` | 286 | 153 |
| `geo-3d` | 302 | 141 |
| `geo-api` | 302 | 146 |
| `geo-inspire` | 335 | 146 |
| `geo-meta` | 415 | 149 |
| `geo-model` | 296 | 133 |
| **Totaal** | **1 936** | **868** |

Reductie: -55%.

`CLAUDE.md` bijgewerkt met expliciete lengte-richtlijn voor toekomstige skills.

## Test plan

- [x] `uv run pytest -q` — 53 passed
- [x] `uvx ruff check / format --check` — schoon
- [ ] Verificatievragen uit `CLAUDE.md` triggeren nog steeds de juiste skills (handmatig na merge)

Refs developer-overheid-nl/skills-marketplace#61