### PR TITLE
fix(geo-api): Delete PDOK API-key section

### DIFF
--- a/skills/geo-api/reference.md
+++ b/skills/geo-api/reference.md
@@ -116,15 +116,6 @@ Query parameters voor `/items`:
 | AHN (hoogtedata) | WCS | `https://service.pdok.nl/rws/ahn/wcs/v1_0` |
 | Bestuurlijke grenzen | WFS | `https://service.pdok.nl/kadaster/bestuurlijkegebieden/wfs/v1_0` |
 
-### PDOK API-key
-
-Voor intensief gebruik van PDOK-services is een API-key beschikbaar. Aanvragen via [pdok.nl](https://www.pdok.nl/). De key wordt meegegeven als HTTP-header:
-
-```bash
-curl -s -H "X-Api-Key: <jouw-key>" \
-  "https://api.pdok.nl/lv/bag/ogc/v1/collections/pand/items?limit=100"
-```
-
 ## Repository Exploratie
 
 ```bash


### PR DESCRIPTION
## Beschrijving

Hi @anneschuth, mooi initiatief! 

Ik zag alleen een stukje over gebruik van API keys voor PDOK. Dat is denk ik een hallucinatie van je LLM, want PDOK gebruikt géén API keys. Het is volledig open en zonder enige vorm van authenticatie/identificatie beschikbaar. 

## Checklist

- [ ] Skills laden correct (`claude --plugin-dir .`)
- [ ] Geen hardcoded paden of persoonlijke gegevens

<!-- Versies en CHANGELOG worden automatisch beheerd door release-please -->
