### PR TITLE
fix(geo-api): verwijder resterende PDOK API-key claim uit troubleshooting

### DIFF
--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -266,7 +266,7 @@ ogr2ogr -f "GeoJSON" /tmp/panden_wgs84.geojson \
 | Lege response bij bbox-filter | Verkeerde coördinaatvolgorde | WMS 1.3.0 respecteert CRS-asvolgorde: voor EPSG:4326 is dat lat/lon; voor EPSG:28992 is het x/y |
 | Timeout bij grote WFS-requests | Te veel features opgevraagd | Gebruik `count`/`maxFeatures` parameter of bbox-filter |
 | `text/xml` in plaats van GeoJSON | outputFormat niet ondersteund | Controleer GetCapabilities voor beschikbare formaten |
-| 403 bij PDOK-service | Rate limiting of IP-blokkade | Gebruik API-key voor intensief gebruik (via PDOK) |
+| 403 bij PDOK-service | Te zware of geblokkeerde request | PDOK-services zijn open zonder API-key; beperk de request (bbox, lagere frequentie) of neem contact op met PDOK bij structurele blokkade |
 | OGC API Features geeft HTML | Geen Accept-header meegegeven | Voeg `Accept: application/geo+json` header toe |
 
 ## Cross-referenties


### PR DESCRIPTION
## Beschrijving

Volgt op #232. Daar is de verzonnen `### PDOK API-key` sectie uit `reference.md` verwijderd, maar dezelfde hallucinatie stond nog in `geo-api/SKILL.md` in de troubleshooting-tabel: bij een 403 werd geadviseerd een PDOK API-key te gebruiken.

PDOK-services zijn volledig open zonder authenticatie ([PDOK FAQ](https://www.pdok.nl/how-to-faq)). De 403-regel is herschreven naar reele mitigaties: bbox, lagere request-frequentie, of contact met PDOK bij structurele blokkade.

## Checklist

- [x] Skills laden correct
- [x] Geen hardcoded paden of persoonlijke gegevens