### PR TITLE
chore: audit-rapporten + niet-blokkerende zichtbaarheidscheck

### DIFF
--- a/.github/workflows/audit-visibility.yml
+++ b/.github/workflows/audit-visibility.yml
@@ -1,0 +1,141 @@
+name: Audit-zichtbaarheid
+
+# Niet-blokkerend. Als een PR een SKILL.md of reference.md raakt en de
+# bijbehorende audit.md bevat UNSUPPORTED_ASSERTION (mogelijke hallucinatie)
+# of CONTRADICTED (bron spreekt de claim tegen), zet deze workflow een label
+# en plaatst een sticky comment met de geflagde claims. De check faalt nooit:
+# het doel is de bevinding in het PR-gesprek krijgen, niet merges tegenhouden.
+# Verscherpen naar blocking kan later, als de false-positive-ratio bekend is.
+
+# pull_request_target i.p.v. pull_request: anders heeft een PR van een externe
+# fork een read-only token en kan de workflow geen label/comment zetten. We
+# checken expliciet de PR-head uit en lezen alleen audit.md (geen uitvoering
+# van PR-code), dus de write-token is hier veilig.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'skills/**/SKILL.md'
+      - 'skills/**/reference.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit-visibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Gewijzigde bestanden via de PR-files-API.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: issue_number },
+            );
+            const skillDirs = new Set();
+            for (const f of files) {
+              const m = f.filename.match(/^(skills\/.+?)\/(SKILL|reference)\.md$/);
+              if (m) skillDirs.add(m[1]);
+            }
+
+            // Per skill: pak de secties UNSUPPORTED_ASSERTION en CONTRADICTED
+            // tot aan de volgende '## ' kop. report.py schrijft die koppen zo.
+            const blocks = [];
+            for (const dir of [...skillDirs].sort()) {
+              const auditPath = path.join(dir, 'audit.md');
+              if (!fs.existsSync(auditPath)) continue;
+              const lines = fs.readFileSync(auditPath, 'utf8').split('\n');
+              const kept = [];
+              let grab = false;
+              for (const line of lines) {
+                if (/^## (UNSUPPORTED_ASSERTION|CONTRADICTED)/.test(line)) {
+                  grab = true;
+                  kept.push(line);
+                } else if (/^## /.test(line)) {
+                  grab = false;
+                } else if (grab) {
+                  kept.push(line);
+                }
+              }
+              if (kept.length) {
+                const slug = dir.replace(/^skills\//, '');
+                blocks.push(`### \`${slug}\`\n\n${kept.join('\n')}`);
+              }
+            }
+
+            const marker = '<!-- audit-visibility -->';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number },
+            );
+            const existing = comments.find(
+              c => c.body && c.body.includes(marker),
+            );
+
+            if (!blocks.length) {
+              // Niets meer geflagd: ruim een oude comment op zodat de PR
+              // niet blijft hangen met een verouderde waarschuwing.
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id,
+                  body: `${marker}\n✅ Audit-zichtbaarheid: geen geflagde `
+                    + `claims meer in de gewijzigde skills.`,
+                });
+              }
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name: 'audit-flagged',
+                });
+              } catch (e) {
+                core.info(`Label niet verwijderd: ${e.message}`);
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              '🔎 **Audit-zichtbaarheid** — deze PR raakt skills met claims '
+                + 'die de audit-pipeline markeerde.',
+              '',
+              '**UNSUPPORTED_ASSERTION** = stellige bewering zonder enige '
+                + 'bronsteun (mogelijke hallucinatie).',
+              '**CONTRADICTED** = een bron spreekt de claim expliciet tegen.',
+              '',
+              'Dit blokkeert de merge niet, maar controleer deze claims '
+                + 'voordat je merget:',
+              '',
+              blocks.join('\n\n'),
+              '',
+              '_Regenereer `audit.md` met de audit-tooling als je de skill '
+                + 'aanpast._',
+            ].join('\n');
+
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: ['audit-flagged'],
+              });
+            } catch (e) {
+              core.info(`Label kon niet worden gezet: ${e.message}`);
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }

--- a/skills/geo-3d/audit.md
+++ b/skills/geo-3d/audit.md
@@ -1,0 +1,580 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo-3d — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 41 | 82% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 2 | 4% |
+| UNGROUNDED | 2 | 4% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 5 | 10% |
+
+*Geverifieerd met sonnet, 6 calls, $0.3734.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (41)
+
+### `geo-3d-0001` — SKILL.md:42 *(§ CityGML)*
+
+> CityGML is de OGC-standaard voor het modelleren en uitwisselen van 3D stadsmodellen met een semantisch model en meerdere Levels of Detail.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML standaard
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *De aangeleverde brontekst is een directory listing van docs.geostandaarden.nl/3d/ met alleen bestandsnamen en datums. Er staat geen inhoudelijke informatie over CityGML of andere standaarden.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/imgeo en bevat geen inhoudelijke informatie over CityGML of andere standaarden.*
+
+### `geo-3d-0002` — SKILL.md:48 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD0 (Regionaal) gebruikt een 2.5D footprint/dakrand als vlakgeometrie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0003` — SKILL.md:49 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD1 (Blokmodel) gebruikt extrusie van footprint als geometrie (blok/prisma).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0004` — SKILL.md:50 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD2 (Basismodel) gebruikt dak- en muurvlakken als oppervlakken met dakvormen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0005` — SKILL.md:51 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD3 (Gedetailleerd) bevat ramen, deuren en balkons als gedetailleerde oppervlakken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0006` — SKILL.md:52 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD4 (Interieur) bevat binnenruimtes en meubels als interieurgeometrie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0007` — SKILL.md:158 *(§ 3D Tiles)*
+
+> 3D Tiles is de OGC-standaard (oorspronkelijk Cesium) voor het streamen van 3D-content voor visualisatie van grote 3D-datasets in webbrowsers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles standaard
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles.*
+
+### `geo-3d-0010` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening heeft de licentie CC BY 4.0 (data: Kadaster).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **NOT_FOUND** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  - *De brontekst vermeldt nergens een licentie (CC BY 4.0 of anderszins).*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de bijbehorende licentie CC BY 4.0.*
+
+### `geo-3d-0015` — SKILL.md:240 *(§ Verschil GIS en BIM)*
+
+> Bij GeoBIM (integratie GIS en BIM) gebruikt GIS het coördinatenstelsel EPSG:28992 (RD New) en BIM lokale (relatieve) coördinaten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over GeoBIM of coördinatenstelsels.*
+
+### `geo-3d-0016` — SKILL.md:243 *(§ Verschil GIS en BIM)*
+
+> GIS (CityGML) gebruikt de formaten GML, CityJSON en GeoJSON; BIM (IFC) gebruikt de formaten IFC en BCF.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over GeoBIM-formaten.*
+
+### `geo-3d-0017` — SKILL.md:244 *(§ Verschil GIS en BIM)*
+
+> GIS-standaarden worden beheerd door OGC en Geonovum; BIM-standaarden door buildingSMART.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over beheerorganisaties van standaarden.*
+
+### `geo-3d-0018` — SKILL.md:275 *(§ Veelvoorkomende Problemen)*
+
+> De LOD 2.2 van de 3D Basisvoorziening is landsdekkend beschikbaar, met fallback naar LOD 1.3.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening LOD
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over de 3D Basisvoorziening of LOD-niveaus.*
+
+### `geo-3d-0019` — SKILL.md:115 *(§ CityJSON Voorbeeld)*
+
+> CityJSON is een compactere JSON-representatie van CityGML.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityJSON
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityJSON.*
+
+### `geo-3d-0020` — reference.md:30 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 3.0 vervangt het LOD0-4 concept (vast) door een flexibel Space concept.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0.*
+
+### `geo-3d-0021` — reference.md:31 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 2.0 ondersteunt alleen GML-encoding; CityGML 3.0 ondersteunt GML, CityJSON en database-encoding.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML encoding-opties.*
+
+### `geo-3d-0022` — reference.md:33 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 3.0 introduceert een Versioning module die in CityGML 2.0 niet aanwezig was.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+
+### `geo-3d-0023` — reference.md:34 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 3.0 introduceert een PointCloud module die in CityGML 2.0 niet aanwezig was.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+
+### `geo-3d-0024` — reference.md:35 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 3.0 introduceert een Dynamizer module voor dynamische data die in CityGML 2.0 niet aanwezig was.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+
+### `geo-3d-0025` — reference.md:44 *(§ LOD1 — Blokmodel)*
+
+> CityGML LOD1 gebruikt Solid-geometrie als extrusie van footprint naar gemiddelde dakrand met uniforme hoogte per gebouw.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0026` — reference.md:49 *(§ LOD2 — Dak- en Muurmodel)*
+
+> CityGML LOD2 gebruikt MultiSurface of Solid met dakvlakken en muurvlakken, inclusief werkelijke dakvormen (plat, schuin, zadeldak).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0027` — reference.md:54 *(§ LOD3 — Architectonisch Model)*
+
+> CityGML LOD3 bevat gedetailleerde oppervlakken inclusief ramen, deuren en balkons; foto-realistische texturen zijn mogelijk.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0028` — reference.md:59 *(§ LOD4 — Interieur Model)*
+
+> CityGML LOD4 bevat binnenruimtes, verdiepingen en kamers; toepassing is indoor navigatie en facilitair management.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+
+### `geo-3d-0029` — reference.md:65 *(§ 3D Basisvoorziening Collecties)*
+
+> De Nederlandse 3D Basisvoorziening biedt 8 collecties via de OGC API op PDOK; brondata is BAG, BGT en AHN (4, 5 en 6) met licentie CC BY 4.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over de 3D Basisvoorziening of PDOK.*
+- **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening, OGC API collecties, BAG/BGT/AHN als brondata, of CC BY 4.0 licentie in deze context.*
+</details>
+
+### `geo-3d-0030` — reference.md:69 *(§ 3D Basisvoorziening Collecties)*
+
+> De collectie '3D Tiles Gebouwen' biedt gebouwen in LOD 2.2 (fallback LOD 1.3) voor visualisatie, gebaseerd op BAG en AHN.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+
+### `geo-3d-0031` — reference.md:71 *(§ 3D Basisvoorziening Collecties)*
+
+> De collectie '3D Objecten Gebouwen' biedt CityJSON met gebouwen LOD 2.2 voor analyse in GIS/BIM, inclusief een IFC converter voor BIM-software.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+
+### `geo-3d-0032` — reference.md:74 *(§ 3D Basisvoorziening Collecties)*
+
+> De collectie 'Digitaal Terreinmodel (DTM)' gebruikt het Quantized Mesh formaat en is gebaseerd op AHN als geïnterpoleerd maaiveld-terreinmodel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+
+### `geo-3d-0033` — reference.md:75 *(§ 3D Basisvoorziening Collecties)*
+
+> De collectie 'DSM 20 cm' biedt een oppervlaktemodel inclusief objecten en vegetatie op 20 cm resolutie in LASZip formaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+
+### `geo-3d-0034` — reference.md:76 *(§ 3D Basisvoorziening Collecties)*
+
+> De collectie 'DSM 8 cm' biedt een hoge-resolutie oppervlaktemodel op 8 cm resolutie in LASZip formaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+
+### `geo-3d-0035` — reference.md:130 *(§ Tile Formaten)*
+
+> 3D Tiles 1.1 introduceert glTF (.glb/.gltf) als nieuw tegelformaat dat het .b3dm formaat vervangt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles tegelformaten
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles tegelformaten.*
+
+### `geo-3d-0036` — reference.md:141 *(§ Geometric Error)*
+
+> In 3D Tiles bepaalt de geometricError (in meters) wanneer een tegel wordt verfijnd; een waarde van 0 betekent een bladtegel zonder verdere verfijning.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles geometric error
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles geometric error.*
+
+### `geo-3d-0037` — reference.md:135 *(§ Refinement Strategieen)*
+
+> In 3D Tiles is de ADD refinement strategie bedoeld voor puntenwolken en terrein; REPLACE voor gebouwen en objecten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles refinement
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles refinement strategieën.*
+
+### `geo-3d-0038` — reference.md:197 *(§ 3D CRS-en)*
+
+> Voor 3D data in Nederland is het standaard CRS EPSG:7415 (RD New horizontaal + NAP hoogte, samengesteld).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D CRS Nederland
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CRS voor 3D data in Nederland.*
+
+### `geo-3d-0039` — reference.md:202 *(§ 3D CRS-en)*
+
+> NAP (Normaal Amsterdams Peil) is het Nederlandse hoogtesysteem. De 3D Basisvoorziening gebruikt EPSG:7415.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D CRS Nederland
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over NAP of EPSG:7415.*
+
+### `geo-3d-0040` — reference.md:150 *(§ val3dity)*
+
+> val3dity is een tool die 3D geometrie valideert en ondersteunt zowel CityGML als CityJSON invoer.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Validatietools
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over validatietools.*
+
+### `geo-3d-0041` — reference.md:163 *(§ cjio (CityJSON CLI))*
+
+> cjio is een CLI-tool waarmee CityJSON kan worden geconverteerd naar GML/OBJ/STL, subsets kunnen worden gemaakt via bbox, en statistieken kunnen worden gegenereerd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Validatietools
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over cjio of CLI-tools.*
+
+### `geo-3d-0042` — reference.md:189 *(§ 3D Conversietools)*
+
+> 3dfier is een conversietool die van 2D data plus AHN hoogte CityGML/CityJSON LOD1 maakt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Conversietools
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3dfier of conversietools.*
+
+### `geo-3d-0043` — SKILL.md:185 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening API-endpoint voor gebouwen 3D Tiles is: https://api.pdok.nl/kadaster/3d-basisvoorziening/ogc/v1/collections/gebouwen/3dtiles
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening API
+
+- **NOT_FOUND** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  - *De brontekst noemt geen specifieke API-endpoint URLs. Alleen de namen van de API's worden vermeld.*
+
+### `geo-3d-0045` — SKILL.md:276 *(§ Veelvoorkomende Problemen)*
+
+> CityJSON niet herkend door software die alleen CityGML/XML ondersteunt kan worden opgelost door conversie met cjio (CityJSON CLI) naar GML.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityJSON compatibiliteit
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityJSON compatibiliteit of conversie.*
+
+### `geo-3d-0046` — reference.md:11 *(§ CityGML 2.0 Namespaces)*
+
+> De CityGML 2.0 core namespace URI is http://www.opengis.net/citygml/2.0 met prefix 'core'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0 Namespaces
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML namespaces.*
+
+### `geo-3d-0047` — reference.md:12 *(§ CityGML 2.0 Namespaces)*
+
+> De CityGML 2.0 building namespace URI is http://www.opengis.net/citygml/building/2.0 met prefix 'bldg'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0 Namespaces
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over CityGML namespaces.*
+
+### `geo-3d-0048` — reference.md:118 *(§ Bounding Volumes)*
+
+> In 3D Tiles tileset.json bevat het 'region' bounding volume de parameters [west, south, east, north, minHeight, maxHeight] in radialen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles bounding volumes
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles bounding volumes.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
+
+### `geo-3d-0008` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening is het landsdekkende 3D-model van Nederland, beschikbaar via PDOK als 8 collecties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > De 3D Basisvoorziening is een verzameling van ruimtelijke bestanden die hoogte informatie bevatten. Er zijn acht collecties beschikbaar.
+  - *De bron bevestigt 'acht collecties' en beschikbaarheid via PDOK, maar omschrijft het niet expliciet als 'landsdekkend 3D-model van Nederland'. Die kwalificatie staat niet letterlijk in de tekst.*
+- **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  - *De brontekst behandelt algemene PDOK FAQ's (atomfeeds, WFS limieten, gebruiksvoorwaarden, etc.) maar vermeldt de 3D Basisvoorziening, 3D-modellen of collecties niet.*
+
+### `geo-3d-0014` — SKILL.md:177 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening biedt toepassingen voor: geluidsmodellering, schaduwanalyse, zonnepotentie, waterafvoerberekeningen, Omgevingswet-plannen en burgercommunicatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening toepassingen
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > het maken van 3D-visualisaties, het uitvoeren van analyses van geluidsmodellen, schaduwanalyse, analyse van zonnepotentie en afwateringsberekeningen. Ook is het een belangrijke basis voor gemeenten bij de planvorming en uitvoering van projecten in het kader van de nieuwe Omgevingswet... In de communicatie met burgers over de impact van de gemaakte plannen op de omgeving is het een waardevol vis...
+  - *Alle genoemde toepassingen worden ondersteund. 'Waterafvoerberekeningen' staat als 'afwateringsberekeningen' in de bron — inhoudelijk equivalent.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (2)
+
+### `geo-3d-0044` — SKILL.md:273 *(§ Veelvoorkomende Problemen)*
+
+> Bij CRS-mismatch in GeoBIM moet IfcMapConversion worden gebruikt om IFC lokale coördinaten te georefereren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** GeoBIM CRS
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over IfcMapConversion of GeoBIM CRS.*
+
+### `geo-3d-0050` — SKILL.md:274 *(§ Veelvoorkomende Problemen)*
+
+> Voor 3D Tiles bij grote of niet geoptimaliseerde tiles wordt aanbevolen de geometric error correct in te stellen en te comprimeren met Draco.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** 3D Tiles optimalisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles optimalisatie of Draco-compressie.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (5)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-3d-0009` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening gebruikt als brondata: BAG, BGT en AHN (versies 4, 5 en 6).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > De bestanden zijn o.a. gebaseerd op topografie uit de Basisregistratie Grootschalige Topografie (BGT), de gebouwen uit de Basisregistratie Adressen en Gebouwen (BAG), en hoogtes uit luchtfotobeelden en het Actueel Hoogtebestand Nederland (AHN 4, 5 en 6).
+
+### `geo-3d-0011` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening is ontwikkeld door het Kadaster in samenwerking met het ministerie van VRO en de TU Delft.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > De 3D Basisvoorziening is gerealiseerd door het Kadaster in samenwerking met het ministerie van VRO (voorheen BZK) en de Technische Universiteit Delft.
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de ontwikkelende partijen (Kadaster, ministerie van VRO, TU Delft).*
+
+### `geo-3d-0012` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening is beschikbaar in de formaten: OGC 3D Tiles, CityJSON (met IFC converter), GeoPackage, Quantized Mesh en LASZip.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > 3D Tiles Gebouwen zijn beschikbaar in het (OGC) 3D Tiles formaat... Het geleverde formaat (CityJSON)... Voor BIM software is een IFC converter beschikbaar... 2D Objecten Gebouwen met hoogte attributen in GeoPackage formaat... Het 3D DTM is beschikbaar in het Quantized Mesh formaat... in LASZip formaat.
+  - *Alle vijf genoemde formaten (OGC 3D Tiles, CityJSON, IFC converter, GeoPackage, Quantized Mesh, LASZip) worden in de bron bevestigd.*
+
+### `geo-3d-0013` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening is beschikbaar via OGC API 3D GeoVolumes en OGC API Features.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
+  > 3D Basisvoorziening (OGC API 3D Geovolumes) — 3D Basisvoorziening (OGC API Features)
+  - *Beide API-typen worden letterlijk als links onderaan de pagina vermeld.*
+
+### `geo-3d-0049` — SKILL.md:38 *(§ Repositories)*
+
+> Het Geonovum GeoBIM repository op GitHub heeft de URL https://github.com/Geonovum/GeoBIM.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM repository
+
+- **SUPPORTED** (high) — [https://github.com/Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM)
+  > Geonovum / GeoBIM Public ... Geonovum/GeoBIM main
+  - *De paginatitel en repository-header tonen duidelijk 'Geonovum / GeoBIM' op GitHub, wat overeenkomt met de geclaimde URL https://github.com/Geonovum/GeoBIM.*
+
+</details>

--- a/skills/geo-3d/audit.md
+++ b/skills/geo-3d/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo-3d — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,476 +7,575 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 41 | 82% |
+| UNSUPPORTED_ASSERTION | 50 | 89% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 2 | 4% |
-| UNGROUNDED | 2 | 4% |
+| PARTIALLY_GROUNDED | 1 | 2% |
+| UNGROUNDED | 1 | 2% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 5 | 10% |
+| GROUNDED | 4 | 7% |
 
-*Geverifieerd met sonnet, 6 calls, $0.3734.*
+*Geverifieerd met sonnet, 5 calls, $0.3441.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (41)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (50)
 
 ### `geo-3d-0001` — SKILL.md:42 *(§ CityGML)*
 
-> CityGML is de OGC-standaard voor het modelleren en uitwisselen van 3D stadsmodellen met een semantisch model en meerdere Levels of Detail.
+> CityGML is de OGC-standaard voor het modelleren en uitwisselen van 3D stadsmodellen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML standaard
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *De aangeleverde brontekst is een directory listing van docs.geostandaarden.nl/3d/ met alleen bestandsnamen en datums. Er staat geen inhoudelijke informatie over CityGML of andere standaarden.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *De brontekst is een directory-index van docs.geostandaarden.nl/imgeo en bevat geen inhoudelijke informatie over CityGML of andere standaarden.*
-
-### `geo-3d-0002` — SKILL.md:48 *(§ Levels of Detail (LOD))*
-
-> CityGML LOD0 (Regionaal) gebruikt een 2.5D footprint/dakrand als vlakgeometrie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/3d/ zonder inhoudelijke tekst over CityGML of andere standaarden.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/imgeo en bevat geen inhoudelijke informatie over CityGML of andere 3D-standaarden.*
 
-### `geo-3d-0003` — SKILL.md:49 *(§ Levels of Detail (LOD))*
+### `geo-3d-0002` — SKILL.md:42 *(§ CityGML)*
 
-> CityGML LOD1 (Blokmodel) gebruikt extrusie van footprint als geometrie (blok/prisma).
+> CityGML definieert een semantisch model met meerdere detailniveaus (Levels of Detail).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke informatie over CityGML.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0004` — SKILL.md:50 *(§ Levels of Detail (LOD))*
+### `geo-3d-0003` — SKILL.md:48 *(§ Levels of Detail (LOD))*
 
-> CityGML LOD2 (Basismodel) gebruikt dak- en muurvlakken als oppervlakken met dakvormen.
+> CityGML LOD0 (Regionaal) heeft als geometrie een 2.5D footprint of dakrand (vlak).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0005` — SKILL.md:51 *(§ Levels of Detail (LOD))*
+### `geo-3d-0004` — SKILL.md:49 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD1 (Blokmodel) heeft als geometrie een extrusie van footprint als blok (prisma).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0005` — SKILL.md:50 *(§ Levels of Detail (LOD))*
+
+> CityGML LOD2 (Basismodel) heeft als geometrie oppervlakken met dakvormen (dak- en muurvlakken).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0006` — SKILL.md:51 *(§ Levels of Detail (LOD))*
 
 > CityGML LOD3 (Gedetailleerd) bevat ramen, deuren en balkons als gedetailleerde oppervlakken.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0006` — SKILL.md:52 *(§ Levels of Detail (LOD))*
+### `geo-3d-0007` — SKILL.md:52 *(§ Levels of Detail (LOD))*
 
-> CityGML LOD4 (Interieur) bevat binnenruimtes en meubels als interieurgeometrie.
+> CityGML LOD4 (Interieur) bevat binnenruimtes en meubels als interieur geometrie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML Levels of Detail
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0007` — SKILL.md:158 *(§ 3D Tiles)*
+### `geo-3d-0008` — SKILL.md:158 *(§ 3D Tiles)*
 
-> 3D Tiles is de OGC-standaard (oorspronkelijk Cesium) voor het streamen van 3D-content voor visualisatie van grote 3D-datasets in webbrowsers.
+> 3D Tiles is de OGC-standaard (oorspronkelijk Cesium) voor het streamen van 3D-content.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles standaard
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0010` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0009` — SKILL.md:158 *(§ 3D Tiles)*
 
-> De 3D Basisvoorziening heeft de licentie CC BY 4.0 (data: Kadaster).
+> 3D Tiles wordt gebruikt voor visualisatie van grote 3D-datasets in webbrowsers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0012` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Basisvoorziening heeft als licentie CC BY 4.0 (data: Kadaster).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
-  - *De brontekst vermeldt nergens een licentie (CC BY 4.0 of anderszins).*
+  - *De brontekst vermeldt geen licentie-informatie (CC BY 4.0 of anderszins).*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de bijbehorende licentie CC BY 4.0.*
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de bijbehorende licentie (CC BY 4.0).*
 
-### `geo-3d-0015` — SKILL.md:240 *(§ Verschil GIS en BIM)*
-
-> Bij GeoBIM (integratie GIS en BIM) gebruikt GIS het coördinatenstelsel EPSG:28992 (RD New) en BIM lokale (relatieve) coördinaten.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over GeoBIM of coördinatenstelsels.*
-
-### `geo-3d-0016` — SKILL.md:243 *(§ Verschil GIS en BIM)*
-
-> GIS (CityGML) gebruikt de formaten GML, CityJSON en GeoJSON; BIM (IFC) gebruikt de formaten IFC en BCF.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over GeoBIM-formaten.*
-
-### `geo-3d-0017` — SKILL.md:244 *(§ Verschil GIS en BIM)*
-
-> GIS-standaarden worden beheerd door OGC en Geonovum; BIM-standaarden door buildingSMART.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over beheerorganisaties van standaarden.*
-
-### `geo-3d-0018` — SKILL.md:275 *(§ Veelvoorkomende Problemen)*
-
-> De LOD 2.2 van de 3D Basisvoorziening is landsdekkend beschikbaar, met fallback naar LOD 1.3.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening LOD
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over de 3D Basisvoorziening of LOD-niveaus.*
-
-### `geo-3d-0019` — SKILL.md:115 *(§ CityJSON Voorbeeld)*
+### `geo-3d-0016` — SKILL.md:115 *(§ CityJSON Voorbeeld)*
 
 > CityJSON is een compactere JSON-representatie van CityGML.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityJSON
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityJSON.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0020` — reference.md:30 *(§ CityGML 3.0 Veranderingen)*
+### `geo-3d-0017` — SKILL.md:230 *(§ GeoBIM — Integratie GIS en BIM)*
 
-> CityGML 3.0 vervangt het LOD0-4 concept (vast) door een flexibel Space concept.
+> GeoBIM combineert geo-informatie (GIS) met bouwinformatie (BIM/IFC).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0021` — reference.md:31 *(§ CityGML 3.0 Veranderingen)*
+### `geo-3d-0018` — SKILL.md:240 *(§ Verschil GIS en BIM)*
 
-> CityGML 2.0 ondersteunt alleen GML-encoding; CityGML 3.0 ondersteunt GML, CityJSON en database-encoding.
+> GIS (CityGML) gebruikt een geografisch coördinatenstelsel (EPSG:28992); BIM (IFC) gebruikt lokale (relatieve) coördinaten.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML encoding-opties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0022` — reference.md:33 *(§ CityGML 3.0 Veranderingen)*
+### `geo-3d-0019` — SKILL.md:241 *(§ Verschil GIS en BIM)*
 
-> CityGML 3.0 introduceert een Versioning module die in CityGML 2.0 niet aanwezig was.
+> GIS (CityGML) hanteert detailniveaus LOD0-3; BIM (IFC) gaat tot constructiedetail.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0023` — reference.md:34 *(§ CityGML 3.0 Veranderingen)*
+### `geo-3d-0020` — SKILL.md:243 *(§ Verschil GIS en BIM)*
 
-> CityGML 3.0 introduceert een PointCloud module die in CityGML 2.0 niet aanwezig was.
+> GIS-formaten zijn GML, CityJSON en GeoJSON; BIM-formaten zijn IFC en BCF.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0024` — reference.md:35 *(§ CityGML 3.0 Veranderingen)*
+### `geo-3d-0021` — SKILL.md:244 *(§ Verschil GIS en BIM)*
 
-> CityGML 3.0 introduceert een Dynamizer module voor dynamische data die in CityGML 2.0 niet aanwezig was.
+> GIS-standaarden worden beheerd door OGC en Geonovum; BIM-standaarden door buildingSMART.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 3.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML 3.0 modules.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0025` — reference.md:44 *(§ LOD1 — Blokmodel)*
+### `geo-3d-0022` — SKILL.md:275 *(§ Veelvoorkomende Problemen)*
 
-> CityGML LOD1 gebruikt Solid-geometrie als extrusie van footprint naar gemiddelde dakrand met uniforme hoogte per gebouw.
+> De 3D Basisvoorziening biedt gebouwen op LOD 2.2 landsdekkend, met fallback naar LOD 1.3.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0026` — reference.md:49 *(§ LOD2 — Dak- en Muurmodel)*
+### `geo-3d-0023` — reference.md:31 *(§ CityGML 3.0 Veranderingen)*
 
-> CityGML LOD2 gebruikt MultiSurface of Solid met dakvlakken en muurvlakken, inclusief werkelijke dakvormen (plat, schuin, zadeldak).
+> CityGML 2.0 ondersteunt alleen GML als encoding; CityGML 3.0 ondersteunt GML, CityJSON en database.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0027` — reference.md:54 *(§ LOD3 — Architectonisch Model)*
+### `geo-3d-0024` — reference.md:30 *(§ CityGML 3.0 Veranderingen)*
 
-> CityGML LOD3 bevat gedetailleerde oppervlakken inclusief ramen, deuren en balkons; foto-realistische texturen zijn mogelijk.
+> CityGML 2.0 hanteert een vast LOD0-4 concept; CityGML 3.0 introduceert een flexibel Space concept.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0028` — reference.md:59 *(§ LOD4 — Interieur Model)*
+### `geo-3d-0025` — reference.md:33 *(§ CityGML 3.0 Veranderingen)*
 
-> CityGML LOD4 bevat binnenruimtes, verdiepingen en kamers; toepassing is indoor navigatie en facilitair management.
+> CityGML 3.0 introduceert een Versioning module; CityGML 2.0 heeft geen ingebouwde versioning.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD specificaties (2.0)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML LOD-specificaties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0029` — reference.md:65 *(§ 3D Basisvoorziening Collecties)*
+### `geo-3d-0026` — reference.md:34 *(§ CityGML 3.0 Veranderingen)*
 
-> De Nederlandse 3D Basisvoorziening biedt 8 collecties via de OGC API op PDOK; brondata is BAG, BGT en AHN (4, 5 en 6) met licentie CC BY 4.0.
+> CityGML 3.0 introduceert een PointCloud module; CityGML 2.0 ondersteunt geen PointCloud.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0027` — reference.md:35 *(§ CityGML 3.0 Veranderingen)*
+
+> CityGML 3.0 introduceert een Dynamizer module; CityGML 2.0 ondersteunt geen dynamiek.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0028` — reference.md:40 *(§ LOD0 — Regionaal Model)*
+
+> CityGML LOD0 heeft geometrietype MultiSurface (footprint of dakrand als vlak) zonder hoogte of met gemiddelde hoogte als attribuut.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD 2.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0029` — reference.md:44 *(§ LOD1 — Blokmodel)*
+
+> CityGML LOD1 heeft geometrietype Solid (extrusie van footprint naar gemiddelde dakrand) met uniforme hoogte per gebouw.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD 2.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0030` — reference.md:49 *(§ LOD2 — Dak- en Muurmodel)*
+
+> CityGML LOD2 heeft geometrietype MultiSurface of Solid met dakvlakken en muurvlakken, inclusief werkelijke dakvormen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD 2.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0031` — reference.md:54 *(§ LOD3 — Architectonisch Model)*
+
+> CityGML LOD3 bevat gedetailleerde oppervlakken inclusief ramen, deuren en balkons, mogelijk met foto-realistische texturen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD 2.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0032` — reference.md:59 *(§ LOD4 — Interieur Model)*
+
+> CityGML LOD4 bevat binnenruimtes, verdiepingen en kamers voor indoor navigatie en facilitair management.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML LOD 2.0
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0033` — reference.md:65 *(§ 3D Basisvoorziening Collecties)*
+
+> De Nederlandse 3D Basisvoorziening biedt 8 collecties via de OGC API op PDOK, met brondata BAG, BGT en AHN (4, 5 en 6) en licentie CC BY 4.0.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over de 3D Basisvoorziening of PDOK.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
-  - *De brontekst bevat geen informatie over de 3D Basisvoorziening, OGC API collecties, BAG/BGT/AHN als brondata, of CC BY 4.0 licentie in deze context.*
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening, OGC API collecties, BAG/BGT/AHN als brondata, of CC BY 4.0 licentie in die context.*
 </details>
 
-### `geo-3d-0030` — reference.md:69 *(§ 3D Basisvoorziening Collecties)*
+### `geo-3d-0034` — reference.md:69 *(§ 3D Basisvoorziening Collecties)*
 
-> De collectie '3D Tiles Gebouwen' biedt gebouwen in LOD 2.2 (fallback LOD 1.3) voor visualisatie, gebaseerd op BAG en AHN.
+> De collectie '3D Tiles Gebouwen' biedt gebouwen in LOD 2.2 (fallback LOD 1.3) in OGC 3D Tiles formaat, op basis van BAG en AHN.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
-
-### `geo-3d-0031` — reference.md:71 *(§ 3D Basisvoorziening Collecties)*
-
-> De collectie '3D Objecten Gebouwen' biedt CityJSON met gebouwen LOD 2.2 voor analyse in GIS/BIM, inclusief een IFC converter voor BIM-software.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0032` — reference.md:74 *(§ 3D Basisvoorziening Collecties)*
+### `geo-3d-0035` — reference.md:71 *(§ 3D Basisvoorziening Collecties)*
 
-> De collectie 'Digitaal Terreinmodel (DTM)' gebruikt het Quantized Mesh formaat en is gebaseerd op AHN als geïnterpoleerd maaiveld-terreinmodel.
+> De collectie '3D Objecten Gebouwen' biedt gebouwen in LOD 2.2 in CityJSON formaat voor analyse in GIS/BIM, met IFC converter voor BIM-software.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0033` — reference.md:75 *(§ 3D Basisvoorziening Collecties)*
+### `geo-3d-0036` — reference.md:74 *(§ 3D Basisvoorziening Collecties)*
 
-> De collectie 'DSM 20 cm' biedt een oppervlaktemodel inclusief objecten en vegetatie op 20 cm resolutie in LASZip formaat.
+> De collectie 'Digitaal Terreinmodel (DTM)' is beschikbaar als Quantized Mesh op basis van AHN en biedt een geïnterpoleerd maaiveld-terreinmodel.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0034` — reference.md:76 *(§ 3D Basisvoorziening Collecties)*
+### `geo-3d-0037` — reference.md:75 *(§ 3D Basisvoorziening Collecties)*
 
-> De collectie 'DSM 8 cm' biedt een hoge-resolutie oppervlaktemodel op 8 cm resolutie in LASZip formaat.
+> De collectie 'DSM 20 cm' is beschikbaar als LASZip en bevat een oppervlaktemodel inclusief objecten en vegetatie met resolutie 20 cm.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening collecties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Basisvoorziening collecties.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0035` — reference.md:130 *(§ Tile Formaten)*
+### `geo-3d-0038` — reference.md:76 *(§ 3D Basisvoorziening Collecties)*
 
-> 3D Tiles 1.1 introduceert glTF (.glb/.gltf) als nieuw tegelformaat dat het .b3dm formaat vervangt.
+> De collectie 'DSM 8 cm' is beschikbaar als LASZip en biedt een hoge-resolutie oppervlaktemodel van 8 cm.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles tegelformaten
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles tegelformaten.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0036` — reference.md:141 *(§ Geometric Error)*
+### `geo-3d-0039` — reference.md:141 *(§ Geometric Error)*
 
-> In 3D Tiles bepaalt de geometricError (in meters) wanneer een tegel wordt verfijnd; een waarde van 0 betekent een bladtegel zonder verdere verfijning.
+> In 3D Tiles bepaalt de geometricError (in meters) wanneer een tegel wordt verfijnd: hogere waarde = later inladen, lagere waarde = eerder vervangen door kinderen, waarde 0 = bladtegel.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles geometric error
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles geometric error.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0037` — reference.md:135 *(§ Refinement Strategieen)*
+### `geo-3d-0040` — reference.md:130 *(§ Tile Formaten)*
 
-> In 3D Tiles is de ADD refinement strategie bedoeld voor puntenwolken en terrein; REPLACE voor gebouwen en objecten.
+> 3D Tiles 1.1 introduceert glTF (.glb/.gltf) als nieuw tile-formaat dat .b3dm vervangt.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles refinement
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles refinement strategieën.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0038` — reference.md:197 *(§ 3D CRS-en)*
+### `geo-3d-0041` — reference.md:136 *(§ Refinement Strategieen)*
 
-> Voor 3D data in Nederland is het standaard CRS EPSG:7415 (RD New horizontaal + NAP hoogte, samengesteld).
+> 3D Tiles refinement strategie ADD voegt kindtegels toe aan de ouder en wordt gebruikt voor puntenwolken en terrein.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0042` — reference.md:137 *(§ Refinement Strategieen)*
+
+> 3D Tiles refinement strategie REPLACE vervangt de ouder door kindtegels en wordt gebruikt voor gebouwen en objecten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0043` — reference.md:202 *(§ 3D CRS-en)*
+
+> Voor 3D data in Nederland is het samengestelde CRS RD + NAP (EPSG:7415) het standaard coördinatenstelsel; de 3D Basisvoorziening gebruikt EPSG:7415.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D CRS Nederland
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CRS voor 3D data in Nederland.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0039` — reference.md:202 *(§ 3D CRS-en)*
+### `geo-3d-0044` — reference.md:202 *(§ 3D CRS-en)*
 
-> NAP (Normaal Amsterdams Peil) is het Nederlandse hoogtesysteem. De 3D Basisvoorziening gebruikt EPSG:7415.
+> NAP (Normaal Amsterdams Peil) is het Nederlandse hoogtesysteem.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D CRS Nederland
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over NAP of EPSG:7415.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0040` — reference.md:150 *(§ val3dity)*
+### `geo-3d-0045` — reference.md:202 *(§ 3D CRS-en)*
 
-> val3dity is een tool die 3D geometrie valideert en ondersteunt zowel CityGML als CityJSON invoer.
+> De brondata voor hoogte in de 3D Basisvoorziening zijn AHN 4, 5 en 6.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0046` — reference.md:150 *(§ val3dity)*
+
+> val3dity is een tool voor het valideren van 3D geometrie (CityGML en CityJSON), afkomstig van TU Delft.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Validatietools
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over validatietools.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0041` — reference.md:163 *(§ cjio (CityJSON CLI))*
+### `geo-3d-0047` — reference.md:185 *(§ 3D Conversietools)*
 
-> cjio is een CLI-tool waarmee CityJSON kan worden geconverteerd naar GML/OBJ/STL, subsets kunnen worden gemaakt via bbox, en statistieken kunnen worden gegenereerd.
+> cjio is een CityJSON CLI tool die conversie ondersteunt van CityJSON naar GML, OBJ en STL.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Validatietools
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over cjio of CLI-tools.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0042` — reference.md:189 *(§ 3D Conversietools)*
+### `geo-3d-0048` — reference.md:189 *(§ 3D Conversietools)*
 
-> 3dfier is een conversietool die van 2D data plus AHN hoogte CityGML/CityJSON LOD1 maakt.
+> 3dfier maakt LOD1 CityGML/CityJSON van 2D data gecombineerd met AHN-hoogte.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Conversietools
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Conversietools
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3dfier of conversietools.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0043` — SKILL.md:185 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0050` — SKILL.md:248 *(§ GeoBIM Workflow)*
 
-> De 3D Basisvoorziening API-endpoint voor gebouwen 3D Tiles is: https://api.pdok.nl/kadaster/3d-basisvoorziening/ogc/v1/collections/gebouwen/3dtiles
+> De GeoBIM workflow omvat: BIM-model (IFC) exporteren, georeferencing, conversie naar CityGML/CityJSON op gewenst LOD, integratie met geo-data, publicatie als 3D Tiles of WFS.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening API
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0051` — SKILL.md:181 *(§ 3D Basisvoorziening via PDOK)*
+
+> De 3D Tiles collectie-API van de 3D Basisvoorziening is bereikbaar op https://api.pdok.nl/kadaster/3d-basisvoorziening/ogc/v1/collections.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **NOT_FOUND** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
-  - *De brontekst noemt geen specifieke API-endpoint URLs. Alleen de namen van de API's worden vermeld.*
+  - *De brontekst vermeldt geen specifieke API-URL's. De URL https://api.pdok.nl/kadaster/3d-basisvoorziening/ogc/v1/collections komt niet voor in de aangeleverde tekst.*
 
-### `geo-3d-0045` — SKILL.md:276 *(§ Veelvoorkomende Problemen)*
+### `geo-3d-0052` — reference.md:11 *(§ CityGML 2.0 Namespaces)*
 
-> CityJSON niet herkend door software die alleen CityGML/XML ondersteunt kan worden opgelost door conversie met cjio (CityJSON CLI) naar GML.
+> De CityGML 2.0 core namespace URI is http://www.opengis.net/citygml/2.0.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityJSON compatibiliteit
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityJSON compatibiliteit of conversie.*
-
-### `geo-3d-0046` — reference.md:11 *(§ CityGML 2.0 Namespaces)*
-
-> De CityGML 2.0 core namespace URI is http://www.opengis.net/citygml/2.0 met prefix 'core'.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0 Namespaces
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML namespaces.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0047` — reference.md:12 *(§ CityGML 2.0 Namespaces)*
+### `geo-3d-0053` — reference.md:12 *(§ CityGML 2.0 Namespaces)*
 
-> De CityGML 2.0 building namespace URI is http://www.opengis.net/citygml/building/2.0 met prefix 'bldg'.
+> De CityGML 2.0 building namespace URI is http://www.opengis.net/citygml/building/2.0 (prefix: bldg).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0 Namespaces
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityGML 2.0
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over CityGML namespaces.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0048` — reference.md:118 *(§ Bounding Volumes)*
+### `geo-3d-0054` — SKILL.md:264 *(§ Digital Twins)*
 
-> In 3D Tiles tileset.json bevat het 'region' bounding volume de parameters [west, south, east, north, minHeight, maxHeight] in radialen.
+> SensorThings API wordt gebruikt voor real-time sensordata in digital twin toepassingen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles bounding volumes
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digital Twins
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles bounding volumes.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
+### `geo-3d-0055` — reference.md:118 *(§ Bounding Volumes)*
 
-### `geo-3d-0008` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+> In 3D Tiles geeft het bounding volume type 'region' parameters [west, south, east, north, minHeight, maxHeight] in radialen en is bedoeld voor geografische data.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Tiles
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+### `geo-3d-0056` — SKILL.md:151 *(§ CityJSON Voorbeeld)*
+
+> CityJSON versie 2.0 gebruikt als referentiesysteem het URI-formaat https://www.opengis.net/def/crs/EPSG/0/7415.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CityJSON
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
+  - *Brontekst bevat alleen een directory-listing.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `geo-3d-0010` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
 
 > De 3D Basisvoorziening is het landsdekkende 3D-model van Nederland, beschikbaar via PDOK als 8 collecties.
 
@@ -484,59 +583,38 @@
 
 - **PARTIALLY_SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
   > De 3D Basisvoorziening is een verzameling van ruimtelijke bestanden die hoogte informatie bevatten. Er zijn acht collecties beschikbaar.
-  - *De bron bevestigt 'acht collecties' en beschikbaarheid via PDOK, maar omschrijft het niet expliciet als 'landsdekkend 3D-model van Nederland'. Die kwalificatie staat niet letterlijk in de tekst.*
+  - *De bron bevestigt 8 collecties en beschikbaarheid via PDOK, maar gebruikt niet het woord 'landsdekkend' expliciet. De scope wordt impliciet aangeduid ('terreinmodel van heel Nederland' bij DTM), maar de claim 'landsdekkend 3D-model van Nederland' als geheel staat niet letterlijk in de bron.*
 - **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
-  - *De brontekst behandelt algemene PDOK FAQ's (atomfeeds, WFS limieten, gebruiksvoorwaarden, etc.) maar vermeldt de 3D Basisvoorziening, 3D-modellen of collecties niet.*
+  - *De brontekst gaat over algemene PDOK FAQ (services, downloads, gebruiksvoorwaarden, WFS-limieten etc.). De 3D Basisvoorziening of 3D-collecties worden nergens genoemd.*
 
-### `geo-3d-0014` — SKILL.md:177 *(§ 3D Basisvoorziening via PDOK)*
+## UNGROUNDED — geen bron ondersteunt de claim (1)
 
-> De 3D Basisvoorziening biedt toepassingen voor: geluidsmodellering, schaduwanalyse, zonnepotentie, waterafvoerberekeningen, Omgevingswet-plannen en burgercommunicatie.
+### `geo-3d-0049` — SKILL.md:273 *(§ Veelvoorkomende Problemen)*
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening toepassingen
+> Bij een CRS-mismatch in GeoBIM moet georeferencing worden toegepast met tools als IfcMapConversion om IFC lokale coördinaten te koppelen aan RD-coördinaten.
 
-- **PARTIALLY_SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
-  > het maken van 3D-visualisaties, het uitvoeren van analyses van geluidsmodellen, schaduwanalyse, analyse van zonnepotentie en afwateringsberekeningen. Ook is het een belangrijke basis voor gemeenten bij de planvorming en uitvoering van projecten in het kader van de nieuwe Omgevingswet... In de communicatie met burgers over de impact van de gemaakte plannen op de omgeving is het een waardevol vis...
-  - *Alle genoemde toepassingen worden ondersteund. 'Waterafvoerberekeningen' staat als 'afwateringsberekeningen' in de bron — inhoudelijk equivalent.*
-
-## UNGROUNDED — geen bron ondersteunt de claim (2)
-
-### `geo-3d-0044` — SKILL.md:273 *(§ Veelvoorkomende Problemen)*
-
-> Bij CRS-mismatch in GeoBIM moet IfcMapConversion worden gebruikt om IFC lokale coördinaten te georefereren.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** GeoBIM CRS
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** GeoBIM
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst bevat alleen een directory-listing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over IfcMapConversion of GeoBIM CRS.*
+  - *Brontekst is een directory-index zonder inhoudelijke specificaties.*
 
-### `geo-3d-0050` — SKILL.md:274 *(§ Veelvoorkomende Problemen)*
-
-> Voor 3D Tiles bij grote of niet geoptimaliseerde tiles wordt aanbevolen de geometric error correct in te stellen en te comprimeren met Draco.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** 3D Tiles optimalisatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/3d/](https://docs.geostandaarden.nl/3d/)
-  - *Aangeleverde brontekst is uitsluitend een directory listing zonder inhoudelijke specificaties.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/imgeo/](https://docs.geostandaarden.nl/imgeo/)
-  - *Directory-index bevat geen inhoudelijke tekst over 3D Tiles optimalisatie of Draco-compressie.*
-
-## GROUNDED — minstens één bron ondersteunt de claim (5)
+## GROUNDED — minstens één bron ondersteunt de claim (4)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `geo-3d-0009` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0011` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
 
-> De 3D Basisvoorziening gebruikt als brondata: BAG, BGT en AHN (versies 4, 5 en 6).
+> De brondata van de 3D Basisvoorziening zijn BAG, BGT en AHN (4, 5 en 6).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
   > De bestanden zijn o.a. gebaseerd op topografie uit de Basisregistratie Grootschalige Topografie (BGT), de gebouwen uit de Basisregistratie Adressen en Gebouwen (BAG), en hoogtes uit luchtfotobeelden en het Actueel Hoogtebestand Nederland (AHN 4, 5 en 6).
 
-### `geo-3d-0011` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0013` — SKILL.md:173 *(§ 3D Basisvoorziening via PDOK)*
 
 > De 3D Basisvoorziening is ontwikkeld door het Kadaster in samenwerking met het ministerie van VRO en de TU Delft.
 
@@ -545,36 +623,26 @@
 - **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
   > De 3D Basisvoorziening is gerealiseerd door het Kadaster in samenwerking met het ministerie van VRO (voorheen BZK) en de Technische Universiteit Delft.
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de ontwikkelende partijen (Kadaster, ministerie van VRO, TU Delft).*
+  - *De brontekst bevat geen informatie over de 3D Basisvoorziening of de betrokken partijen (ministerie van VRO, TU Delft).*
 
-### `geo-3d-0012` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0014` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
 
-> De 3D Basisvoorziening is beschikbaar in de formaten: OGC 3D Tiles, CityJSON (met IFC converter), GeoPackage, Quantized Mesh en LASZip.
+> De 3D Basisvoorziening biedt data in de formaten OGC 3D Tiles, CityJSON, GeoPackage, Quantized Mesh en LASZip.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
-  > 3D Tiles Gebouwen zijn beschikbaar in het (OGC) 3D Tiles formaat... Het geleverde formaat (CityJSON)... Voor BIM software is een IFC converter beschikbaar... 2D Objecten Gebouwen met hoogte attributen in GeoPackage formaat... Het 3D DTM is beschikbaar in het Quantized Mesh formaat... in LASZip formaat.
-  - *Alle vijf genoemde formaten (OGC 3D Tiles, CityJSON, IFC converter, GeoPackage, Quantized Mesh, LASZip) worden in de bron bevestigd.*
+  > De 3D Tiles Gebouwen zijn beschikbaar in het (OGC) 3D Tiles formaat [...] Het geleverde formaat (CityJSON) [...] in GeoPackage formaat [...] Het 3D DTM is beschikbaar in het Quantized Mesh formaat [...] in LASZip formaat.
+  - *Alle vijf formaten worden expliciet genoemd in de brontekst, verspreid over de beschrijvingen van de afzonderlijke collecties.*
 
-### `geo-3d-0013` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
+### `geo-3d-0015` — SKILL.md:175 *(§ 3D Basisvoorziening via PDOK)*
 
 > De 3D Basisvoorziening is beschikbaar via OGC API 3D GeoVolumes en OGC API Features.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** 3D Basisvoorziening
 
 - **SUPPORTED** (high) — [https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1](https://www.pdok.nl/introductie/-/article/3d-basisvoorziening-1)
-  > 3D Basisvoorziening (OGC API 3D Geovolumes) — 3D Basisvoorziening (OGC API Features)
-  - *Beide API-typen worden letterlijk als links onderaan de pagina vermeld.*
-
-### `geo-3d-0049` — SKILL.md:38 *(§ Repositories)*
-
-> Het Geonovum GeoBIM repository op GitHub heeft de URL https://github.com/Geonovum/GeoBIM.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoBIM repository
-
-- **SUPPORTED** (high) — [https://github.com/Geonovum/GeoBIM](https://github.com/Geonovum/GeoBIM)
-  > Geonovum / GeoBIM Public ... Geonovum/GeoBIM main
-  - *De paginatitel en repository-header tonen duidelijk 'Geonovum / GeoBIM' op GitHub, wat overeenkomt met de geclaimde URL https://github.com/Geonovum/GeoBIM.*
+  > 3D Basisvoorziening (OGC API 3D Geovolumes) 3D Basisvoorziening (OGC API Features)
+  - *Beide API-types worden vermeld in de links onderaan de pagina. De claim schrijft '3D GeoVolumes' (met hoofdletter G), de bron schrijft 'Geovolumes' (kleine v), maar de strekking is identiek.*
 
 </details>

--- a/skills/geo-api/audit.md
+++ b/skills/geo-api/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo-api — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,628 +7,547 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 20 | 51% |
+| UNSUPPORTED_ASSERTION | 9 | 27% |
 | CONTRADICTED | 1 | 3% |
-| PARTIALLY_GROUNDED | 5 | 13% |
-| UNGROUNDED | 8 | 21% |
+| PARTIALLY_GROUNDED | 7 | 21% |
+| UNGROUNDED | 7 | 21% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 5 | 13% |
+| GROUNDED | 9 | 27% |
 
-*Geverifieerd met sonnet, 7 calls, $0.7463.*
+*Geverifieerd met sonnet, 11 calls, $0.9129.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (20)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (9)
 
-### `geo-api-0003` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+### `geo-api-0004` — SKILL.md:24 *(§ OGC API Services & Kaartdiensten)*
 
-> WMS is aanbevolen door het Forum Standaardisatie (sinds september 2024).
+> Geonovum beheert de Nederlandse profielen en de ogc-checker validatietool.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS — Forum Standaardisatie status
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WMS of Forum Standaardisatie status.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS en Forum Standaardisatie aanbevelingen worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WMS Forum Standaardisatie status wordt niet behandeld in deze bron.*
-</details>
-
-### `geo-api-0004` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
-
-> WFS is aanbevolen door het Forum Standaardisatie (sinds september 2024).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS — Forum Standaardisatie status
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum — ogc-checker
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WFS of Forum Standaardisatie status.*
+  - *Geonovum en ogc-checker worden niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WFS en Forum Standaardisatie aanbevelingen worden niet behandeld in deze bron.*
+  - *Geonovum wordt enkel vermeld als editor, niet als beheerder van profielen of ogc-checker.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WFS Forum Standaardisatie status wordt niet behandeld in deze bron.*
+  - *De ogc-checker of Geonovum's beheersrol over Nederlandse profielen en validatietool worden niet vermeld in de bron.*
 </details>
 
 ### `geo-api-0005` — SKILL.md:30 *(§ Standaarden Overzicht)*
 
-> OGC API Features heeft Forum-status 'Verplicht'.
+> OGC API Features is een REST-gebaseerde opvolger van WFS met JSON/GeoJSON en heeft Forum-status 'Verplicht'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — standaardenoverzicht
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum-status van standaarden.*
+  - *De brontekst bevat geen inhoudelijke informatie over OGC API Features.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *Forum-status van OGC API Features wordt niet vermeld in deze bron.*
+  - *OGC API Features wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Forum-status van OGC API Features wordt niet vermeld in de bron.*
+  - *OGC API Features als REST-opvolger van WFS wordt niet als zodanig beschreven en Forum-status 'Verplicht' staat niet in de bron.*
 </details>
 
 ### `geo-api-0006` — SKILL.md:31 *(§ Standaarden Overzicht)*
 
-> OGC API Tiles heeft Forum-status 'Verplicht'.
+> OGC API Tiles is de opvolger van WMTS voor voorgerenderde kaarttegels en heeft Forum-status 'Verplicht'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Tiles — standaardenoverzicht
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Tiles — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum-status van standaarden.*
+  - *De brontekst bevat geen inhoudelijke informatie over OGC API Tiles.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *Forum-status van OGC API Tiles wordt niet vermeld in deze bron.*
+  - *OGC API Tiles wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *OGC API Tiles en Forum-status worden niet behandeld in de bron.*
+  - *OGC API Tiles en WMTS worden niet besproken in de bron.*
 </details>
 
 ### `geo-api-0007` — SKILL.md:32 *(§ Standaarden Overzicht)*
 
-> WMS 1.3.0 heeft Forum-status 'Aanbevolen'.
+> WMS 1.3.0 heeft Forum-status 'Aanbevolen' en wordt gebruikt voor het opvragen van kaartafbeeldingen (PNG/JPEG).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS 1.3.0 — standaardenoverzicht
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS 1.3.0 — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WMS 1.3.0 Forum-status.*
+  - *De brontekst bevat geen inhoudelijke informatie over WMS 1.3.0 of Forum status.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *Forum-status van WMS 1.3.0 wordt niet vermeld in deze bron.*
+  - *WMS 1.3.0 wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WMS 1.3.0 Forum-status wordt niet behandeld in de bron.*
+  - *WMS 1.3.0 en Forum-status 'Aanbevolen' worden niet besproken in de bron.*
 </details>
 
 ### `geo-api-0008` — SKILL.md:33 *(§ Standaarden Overzicht)*
 
-> WFS 2.0 heeft Forum-status 'Aanbevolen'.
+> WFS 2.0 heeft Forum-status 'Aanbevolen' en wordt gebruikt voor het opvragen van vector features (GML/GeoJSON).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS 2.0 — standaardenoverzicht
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS 2.0 — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WFS 2.0 Forum-status.*
+  - *De brontekst bevat geen inhoudelijke informatie over WFS 2.0 of Forum status.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *Forum-status van WFS 2.0 wordt niet vermeld in deze bron.*
+  - *WFS 2.0 wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WFS 2.0 Forum-status wordt niet behandeld in de bron.*
+  - *WFS 2.0 en Forum-status 'Aanbevolen' worden niet besproken in de bron.*
 </details>
 
 ### `geo-api-0009` — SKILL.md:34 *(§ Standaarden Overzicht)*
 
-> WCS 2.0 heeft geen Forum-status.
+> WCS 2.0 heeft geen Forum Standaardisatie status en wordt gebruikt voor het ophalen van rasterdata (gridded data).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WCS 2.0 — standaardenoverzicht
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WCS 2.0 — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WCS 2.0 Forum-status.*
+  - *WCS 2.0 wordt niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WCS 2.0 en Forum-status worden niet behandeld in deze bron.*
+  - *WCS 2.0 wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WCS 2.0 wordt niet genoemd in de bron.*
+  - *WCS 2.0 en rasterdata worden niet besproken in de bron.*
 </details>
 
 ### `geo-api-0010` — SKILL.md:35 *(§ Standaarden Overzicht)*
 
-> GeoPackage 1.3.1 heeft Forum-status 'Verplicht'.
+> GeoPackage 1.3.1 heeft Forum-status 'Verplicht' en is een SQLite-gebaseerd bestandsformaat voor lokale opslag van vector- en rasterdata.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoPackage 1.3.1 — standaardenoverzicht
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over GeoPackage Forum-status.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *GeoPackage 1.3.1 en Forum-status worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *GeoPackage wordt niet genoemd in de bron.*
-</details>
-
-### `geo-api-0011` — SKILL.md:35 *(§ Standaarden Overzicht)*
-
-> GeoPackage 1.3.1 is een SQLite-gebaseerd bestandsformaat voor lokale opslag van vector- en rasterdata.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoPackage 1.3.1
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoPackage 1.3.1 — Forum Standaardisatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van GeoPackage.*
+  - *GeoPackage wordt niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   - *GeoPackage wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *GeoPackage wordt niet behandeld in de bron.*
+  - *GeoPackage wordt niet vermeld in de bron.*
 </details>
 
-### `geo-api-0012` — SKILL.md:41 *(§ Repositories)*
-
-> De ogc-checker is versie v1.0.4 en is een validatietool van Geonovum voor OGC-services.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker — Geonovum validatietool
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over de ogc-checker tool of versienummers.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De ogc-checker validatietool wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De ogc-checker wordt niet genoemd in de bron.*
-</details>
-
-### `geo-api-0013` — SKILL.md:41 *(§ Repositories)*
-
-> De ogc-checker is gepubliceerd onder de EUPL-1.2 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker — licentie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen licentie-informatie over de ogc-checker.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De ogc-checker licentie wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De ogc-checker en licentie worden niet behandeld in de bron.*
-</details>
-
-### `geo-api-0014` — SKILL.md:48 *(§ WMS (Web Map Service))*
+### `geo-api-0012` — SKILL.md:48 *(§ WMS (Web Map Service))*
 
 > WMS ondersteunt drie operaties: GetCapabilities, GetMap en GetFeatureInfo.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS (Web Map Service)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS — operaties
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van WMS-operaties.*
+  - *WMS-operaties worden niet beschreven in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS-operaties worden niet beschreven in deze bron.*
+  - *WMS-operaties worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WMS-operaties worden niet beschreven in deze bron.*
+  - *WMS-operaties (GetCapabilities, GetMap, GetFeatureInfo) worden niet besproken in de bron.*
 </details>
 
-### `geo-api-0015` — SKILL.md:77 *(§ WFS (Web Feature Service))*
+### `geo-api-0013` — SKILL.md:77 *(§ WFS (Web Feature Service))*
 
 > WFS ondersteunt de operaties GetCapabilities, DescribeFeatureType en GetFeature.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS (Web Feature Service)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS — operaties
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van WFS-operaties.*
+  - *WFS-operaties worden niet beschreven in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WFS-operaties worden niet beschreven in deze bron.*
+  - *WFS-operaties worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WFS-operaties worden niet beschreven in deze bron.*
-</details>
-
-### `geo-api-0021` — reference.md:12 *(§ Coördinaatreferentiesystemen (CRS))*
-
-> ETRS89 / UTM zone 31N heeft EPSG-code 25831 en wordt gebruikt voor INSPIRE en Europese data.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — ETRS89 UTM 31N
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over ETRS89 UTM 31N of INSPIRE.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *ETRS89 UTM 31N / EPSG:25831 wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *ETRS89 / UTM zone 31N (EPSG:25831) wordt niet vermeld in de bron. De bron noemt ETRS89 (EPSG:4258 en 4937) maar niet UTM zone 31N.*
-</details>
-
-### `geo-api-0026` — reference.md:22 *(§ Coördinaatvolgorde)*
-
-> WFS 2.0 volgt de CRS-definitie voor coördinaatvolgorde, tenzij anders geconfigureerd.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS 2.0 — coördinaatvolgorde
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WFS 2.0.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron beschrijft de NLGov REST API Design Rules (ADR v2.1.0). WFS 2.0 coördinaatvolgorde wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt WFS 2.0 niet; de bron gaat uitsluitend over de API Design Rules Module Geospatial en OGC API Features.*
-</details>
-
-### `geo-api-0033` — reference.md:88 *(§ OGC API Features Endpoints)*
-
-> OGC API Features biedt het endpoint `/conformance` (GET) voor conformance classes.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron verwijst naar OGC API Features maar noemt het /conformance endpoint niet expliciet. Alleen /collections en /crss worden als voorbeeldendpoints genoemd.*
-</details>
-
-### `geo-api-0034` — reference.md:92 *(§ OGC API Features Endpoints)*
-
-> OGC API Features biedt het endpoint `/collections/{id}/items` (GET) voor features in GeoJSON-formaat.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron verwijst naar OGC API Features collecties en items (bijv. /collections/gebouwen/items) in voorbeelden, maar specificeert het endpoint /collections/{id}/items niet als formeel endpoint met de eigenschap 'GeoJSON-formaat'. Het wordt impliciet gebruikt in voorbeelden maar niet als formele specificatie van het endpoint beschreven.*
-</details>
-
-### `geo-api-0035` — reference.md:94 *(§ OGC API Features Endpoints)*
-
-> OGC API Features biedt het endpoint `/api` (GET) voor de OpenAPI specificatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron noemt het /api endpoint voor de OpenAPI specificatie niet.*
-</details>
-
-### `geo-api-0036` — reference.md:97 *(§ OGC API Features Endpoints)*
-
-> De `limit` query parameter voor OGC API Features `/items` heeft een standaardwaarde van 10; het maximum verschilt per service.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — query parameters
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over query parameters van OGC API Features.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De `limit` query parameter voor OGC API Features wordt niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt de `limit` query parameter en de standaardwaarde van 10 niet.*
-</details>
-
-### `geo-api-0038` — reference.md:99 *(§ OGC API Features Endpoints)*
-
-> De `datetime` query parameter voor OGC API Features `/items` gebruikt ISO 8601 formaat.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — datetime parameter
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over de datetime parameter van OGC API Features.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De `datetime` query parameter voor OGC API Features wordt niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt de `datetime` query parameter niet.*
+  - *WFS-operaties worden niet besproken in de bron.*
 </details>
 
 ## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
 
-### `geo-api-0022` — reference.md:13 *(§ Coördinaatreferentiesystemen (CRS))*
+### `geo-api-0019` — reference.md:12 *(§ Belangrijkste CRS-en in Nederland)*
 
-> WGS 84 heeft EPSG-code 4326 en coördinaatvolgorde lat, lon (breedte, lengte) in graden.
+> ETRS89 / UTM zone 31N heeft EPSG-code 25831 en wordt gebruikt voor INSPIRE en Europese data, met coördinaatvolgorde x, y (oost, noord) in meters.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — WGS 84
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — ETRS89
 
 - **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > WGS 84 longitude-latitude | CRS84 | longitude, latitude (λ, φ) | 2D | Global | http://www.opengis.net/def/crs/OGC/1.3/CRS84
-  - *De bron geeft WGS 84 longitude-latitude de naam CRS84 met coördinaatvolgorde lon, lat, niet EPSG:4326. EPSG:4326 wordt niet als apart item vermeld in de CRS-tabel. De claim dat WGS 84 EPSG-code 4326 heeft en lat/lon volgorde kent is daarmee strijdig met hoe de bron WGS 84 / CRS84 presenteert (lon, lat volgorde).*
+  > ETRS89 4258 latitude, longitude (φ, λ) 2D European
+  - *De claim stelt ETRS89/UTM zone 31N met EPSG:25831, maar de bron beschrijft ETRS89 als EPSG:4258 (geografisch, lat/lon). EPSG:25831 (UTM zone 31N) wordt niet vermeld. De coördinaatvolgorde in de claim (x, y oost/noord in meters) klopt niet met de bron (lat, lon in graden).*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over WGS 84 of EPSG:4326.*
+  - *ETRS89 / EPSG:25831 wordt niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WGS 84 / EPSG:4326 coördinaatvolgorde wordt niet behandeld in deze bron.*
+  - *ETRS89 / UTM zone 31N (EPSG:25831) wordt niet behandeld in deze bron.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (5)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (7)
 
-### `geo-api-0016` — SKILL.md:134 *(§ OGC API Features)*
+### `geo-api-0003` — SKILL.md:24 *(§ OGC API Services & Kaartdiensten)*
 
-> OGC API Features is de REST-gebaseerde opvolger van WFS en gebruikt JSON/GeoJSON, een OpenAPI-specificatie en standaard HTTP-methoden.
+> PDOK is het nationale portaal voor geo-webservices in Nederland.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** PDOK
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > Support GeoJSON as described in OGC API Features Requirements class 8.3 [...] Support GeoJSON as described in OGC API Features part 4 [...] Note The Geospatial Module is focused on JSON-based encoding of data.
-  - *De bron bevestigt dat OGC API Features JSON/GeoJSON en een OpenAPI-specificatie gebruikt en verwijst naar OGC API Features standaarden, maar beschrijft OGC API Features niet expliciet als 'de REST-gebaseerde opvolger van WFS' en noemt 'standaard HTTP-methoden' niet expliciet in die context.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  > Iedereen mag kosteloos data afnemen bij PDOK. [...] Via PDOK kunnen diverse datasets worden "gedownload". [...] De Nederlandse geo-infrastructuur ontsluit gegevens middels een aantal Open Geospatial Consortium (OGC) standaarden.
+  - *De bron beschrijft PDOK als een portaal voor open geodata en geo-webservices, maar gebruikt nergens expliciet de term 'nationaal portaal'. De rol als nationaal portaal is impliciet aanwezig maar niet letterlijk gesteld.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van OGC API Features.*
+  - *PDOK wordt niet genoemd in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *OGC API Features als opvolger van WFS wordt niet beschreven in deze bron. De bron verwijst alleen naar de geospatial module via /core/geospatial maar beschrijft OGC API Features zelf niet.*
+  - *PDOK wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *PDOK wordt in de brontekst niet genoemd.*
+</details>
 
-### `geo-api-0019` — SKILL.md:270 *(§ Veelvoorkomende Problemen)*
+### `geo-api-0011` — SKILL.md:41 *(§ Repositories)*
 
-> OGC API Features geeft HTML terug als er geen Accept-header wordt meegegeven; de correcte header is `Accept: application/geo+json`.
+> De ogc-checker van Geonovum heeft versie v1.0.4 en is gepubliceerd onder EUPL-1.2 licentie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OGC API Features — Accept-header
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum ogc-checker
+
+- **PARTIALLY_SUPPORTED** (high) — [https://raw.githubusercontent.com/Geonovum/ogc-checker/main/LICENSE](https://raw.githubusercontent.com/Geonovum/ogc-checker/main/LICENSE)
+  > EUROPEAN UNION PUBLIC LICENCE v. 1.2 EUPL © the European Union 2007, 2016
+  - *De bron bevestigt de EUPL-1.2 licentie, maar bevat geen informatie over versienummer v1.0.4. Versie-metadata staat zelden in de LICENSE-file zelf.*
+- **PARTIALLY_SUPPORTED** (high) — [https://raw.githubusercontent.com/Geonovum/ogc-checker/master/LICENSE](https://raw.githubusercontent.com/Geonovum/ogc-checker/master/LICENSE)
+  > EUROPEAN UNION PUBLIC LICENCE v. 1.2 EUPL © the European Union 2007, 2016
+  - *De bron bevestigt de EUPL-1.2 licentie. De versieclaim 'v1.0.4' staat niet in de brontekst — een LICENSE-bestand bevat geen versie-metadata van de software zelf.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De ogc-checker versie en licentie worden niet vermeld in de directory-index.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De ogc-checker van Geonovum wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De ogc-checker, versienummer en licentie worden niet vermeld in de bron.*
+</details>
+
+### `geo-api-0017` — SKILL.md:270 *(§ Veelvoorkomende Problemen)*
+
+> OGC API Features geeft HTML terug als er geen Accept-header wordt meegegeven; oplossing is `Accept: application/geo+json` header toevoegen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OGC API Features — content negotiation
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
   > Note The Geospatial Module is focused on JSON-based encoding of data. However, consider also supporting text/html, as recommended in OGC API Features [ogcapi-features-1]. Sharing data on the Web should include publication in HTML, as this allows discovery of the data through common search engines as well as viewing the data directly in a browser.
-  - *De bron bevestigt dat HTML ondersteund wordt en dat application/geo+json de media type is voor geospatiale responses, maar zegt niet expliciet dat HTML de default is bij ontbrekende Accept-header.*
+  - *De bron bevestigt dat HTML ondersteund wordt in OGC API Features, maar zegt niets over het standaard gedrag zonder Accept-header (HTML teruggeven) of de aanbeveling om Accept: application/geo+json toe te voegen als oplossing.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over Accept-headers bij OGC API Features.*
+  - *Content negotiation bij OGC API Features wordt niet behandeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *OGC API Features Accept-header gedrag wordt niet beschreven in deze bron.*
+  - *OGC API Features content negotiation wordt niet behandeld in deze bron.*
 
-### `geo-api-0025` — reference.md:21 *(§ Coördinaatvolgorde)*
+### `geo-api-0020` — reference.md:13 *(§ Belangrijkste CRS-en in Nederland)*
 
-> WMS 1.3.0 volgt de CRS-definitie voor coördinaatvolgorde: voor EPSG:4326 is dat lat/lon (y,x), voor EPSG:28992 is dat x,y.
+> WGS 84 heeft EPSG-code 4326, wordt gebruikt voor GPS en internationaal gebruik, met coördinaatvolgorde lat, lon (breedte, lengte) in graden.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS 1.3.0 — coördinaatvolgorde
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > ETRS89 | 4258 | latitude, longitude (φ, λ) | 2D | European [...] Amersfoort / RD New | 28992 | easting, northing (x, y) | 2D | Dutch
-  - *De CRS-tabel bevestigt lat/lon voor EPSG:4258 en x/y voor EPSG:28992. De bron zegt echter niet expliciet dat dit het gevolg is van de WMS 1.3.0 specificatie of een WMS GetMap-context; het is een algemene CRS-tabel zonder WMS-specifieke context.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WMS 1.3.0.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS 1.3.0 coördinaatvolgorde per CRS wordt niet behandeld in deze bron.*
-
-### `geo-api-0027` — reference.md:23 *(§ Coördinaatvolgorde)*
-
-> OGC API Features gebruikt standaard CRS84 (lon/lat); andere CRS zijn opvraagbaar via de `crs` parameter.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — standaard CRS
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > The default CRS for GeoJSON and for OGC API Features is CRS84 (OGC:CRS84), this CRS uses the WGS 84 datum with an ellipsoidal coordinate system in the order longitude-latitude.
-  - *De bron bevestigt CRS84 als standaard, en vermeldt de `crs` parameter (/geo/crs-query-parameter). Echter, de bron noemt de `crs` parameter als een header-mechanisme (Content-Crs) én als query parameter apart — het 'opvraagbaar via de crs parameter' klopt, maar de bron legt ook uit dat andere CRS via bbox-crs en filter-crs beschikbaar zijn. Het woordje 'andere CRS zijn opvraagbaar via de crs parameter' is slechts gedeeltelijk gedekt.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over standaard CRS bij OGC API Features.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron behandelt de NLGov REST API Design Rules. OGC API Features standaard CRS en crs parameter specificaties vallen buiten de scope van deze bron.*
-
-### `geo-api-0037` — reference.md:98 *(§ OGC API Features Endpoints)*
-
-> De `bbox` query parameter voor OGC API Features `/items` heeft de volgorde lon_min,lat_min,lon_max,lat_max.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — bbox parameter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — WGS 84
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > Support the OGC API Features part 1 bbox query parameter in conformance to the standard. Example: GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2
-  - *Het voorbeeld toont lon_min,lat_min,lon_max,lat_max volgorde (5.4,52.1,5.5,53.2) wat overeenkomt met de claim, maar de bron specificeert de volgorde niet expliciet als definitie — het verwijst naar OGC API Features part 1 als de standaard. De volgorde is impliciet af te leiden uit het voorbeeld.*
+  > WGS 84 longitude-latitude CRS84 longitude, latitude (λ, φ) 2D Global http://www.opengis.net/def/crs/OGC/1.3/CRS84
+  - *De bron vermeldt WGS 84 maar koppelt het primair aan CRS84 (OGC) met lon/lat volgorde. EPSG:4326 met lat/lon volgorde voor GPS/internationaal gebruik wordt niet expliciet als zodanig beschreven. De bron noemt WGS 84 Pseudo Mercator EPSG:3857 apart.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over de bbox parameter van OGC API Features.*
+  - *WGS 84 / EPSG:4326 wordt niet vermeld in de directory-index.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WGS 84 (EPSG:4326) coördinaatvolgorde wordt niet behandeld in deze bron.*
+
+### `geo-api-0022` — reference.md:15 *(§ Belangrijkste CRS-en in Nederland)*
+
+> ETRS89 geografisch heeft EPSG-code 4258, is verplicht voor INSPIRE, en heeft coördinaatvolgorde lat, lon (breedte, lengte) in graden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — ETRS89 geografisch, INSPIRE
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > ETRS89 4258 latitude, longitude (φ, λ) 2D European
+  - *De bron bevestigt EPSG:4258 en lat/lon volgorde voor ETRS89 geografisch. Dat het 'verplicht voor INSPIRE' is wordt niet in de bron vermeld.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *ETRS89 geografisch / EPSG:4258 wordt niet vermeld in de directory-index.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *ETRS89 geografisch (EPSG:4258) en INSPIRE worden niet behandeld in deze bron.*
+
+### `geo-api-0032` — reference.md:93 *(§ OGC API Features Endpoints)*
+
+> OGC API Features definieert de endpoints `/`, `/conformance`, `/collections`, `/collections/{id}`, `/collections/{id}/items`, `/collections/{id}/items/{featureId}` en `/api`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > According to OGC API Features - part 1 - 7.13. Feature collections an OGC API Features API shall provide a GET operation on the /collections endpoint which returns a collections object.
+  - *De bron noemt `/collections` en `/collections/{id}` (storageCRS context) en `/collections/{id}/items` (via bbox-voorbeelden). De endpoints `/`, `/conformance`, `/collections/{id}/items/{featureId}` en `/api` worden niet expliciet als lijst opgesomd. De claim is gebaseerd op OGC API Features part 1 maar de bron vermeldt niet alle genoemde endpoints expliciet.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *OGC API Features endpoints worden niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De `bbox` query parameter volgorde voor OGC API Features wordt niet behandeld in deze ADR-bron.*
+  - *De bron behandelt geen OGC API Features endpoints. De geospatiale module wordt slechts als verwijzing naar een extern document vermeld.*
 
-## UNGROUNDED — geen bron ondersteunt de claim (8)
+### `geo-api-0033` — reference.md:101 *(§ OGC API Features Endpoints)*
 
-### `geo-api-0001` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+> OGC API Features `/items` endpoint ondersteunt query parameters: `limit`, `bbox` (lon_min,lat_min,lon_max,lat_max), `datetime` (ISO 8601), `crs` (standaard CRS84) en additionele property-filters.
 
-> OGC API Features is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — /items query parameters
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OGC API Features — Forum Standaardisatie status
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Support the OGC API Features part 1 bbox query parameter in conformance to the standard. [...] Support the OGC API Features part 2 crs parameter in conformance to the standard. [...] The default CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84.
+  - *De bron bevestigt `bbox` en `crs` als query parameters voor `/items`. De parameters `limit`, `datetime` en additionele property-filters worden in deze brontekst niet expliciet bij het `/items` endpoint vermeld, ook de exacte volgorde `lon_min,lat_min,lon_max,lat_max` voor bbox wordt niet letterlijk bevestigd (wel impliciet via OGC API Features conformance).*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *OGC API Features /items query parameters worden niet behandeld in de directory-index.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron behandelt geen OGC API Features `/items` endpoint of bijbehorende query parameters. Dit valt buiten de scope van de NLGov REST API Design Rules.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (7)
+
+### `geo-api-0015` — SKILL.md:266 *(§ Veelvoorkomende Problemen)*
+
+> Bij WMS 1.3.0 geeft een lege response bij bbox-filter een oorzaak: verkeerde coördinaatvolgorde. Voor EPSG:4326 is de asvolgorde lat/lon; voor EPSG:28992 is het x/y.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — CRS coördinaatvolgorde
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index van docs.geostandaarden.nl/api en bevat geen inhoudelijke informatie over Forum Standaardisatie status van standaarden.*
+  - *Coördinaatvolgorde en bbox-problemen bij WMS 1.3.0 worden niet behandeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron is de NLGov REST API Design Rules 2.1.0 specificatie. OGC API Features en Forum Standaardisatie 'pas-toe-of-leg-uit' status worden niet behandeld.*
+  - *WMS 1.3.0 coördinaatvolgorde wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de inhoud van de Geospatial Module (ADR), niet de Forum Standaardisatie status van OGC API Features.*
+  - *WMS 1.3.0 bbox-filter problemen en coördinaatvolgorde als debugtip worden niet besproken in de bron.*
 </details>
 
-### `geo-api-0002` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+### `geo-api-0024` — reference.md:26 *(§ Coördinaatvolgorde)*
 
-> OGC API Tiles is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+> WMS 1.3.0 volgt de CRS-definitie voor asvolgorde: voor EPSG:4326 is dat lat/lon (y,x), voor EPSG:28992 is dat x,y.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OGC API Tiles — Forum Standaardisatie status
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — coördinaatvolgorde
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum Standaardisatie status.*
+  - *WMS 1.3.0 coördinaatvolgorde wordt niet behandeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron behandelt OGC API Tiles noch Forum Standaardisatie verplichtingen.*
+  - *WMS 1.3.0 coördinaatvolgorde wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *OGC API Tiles wordt in de bron niet genoemd, en Forum Standaardisatie status staat niet in de bron.*
+  - *WMS 1.3.0 coördinaatvolgorde per CRS wordt niet besproken in de bron; de bron gaat over REST API / OGC API Features regels.*
 </details>
 
-### `geo-api-0017` — SKILL.md:266 *(§ Veelvoorkomende Problemen)*
+### `geo-api-0025` — reference.md:27 *(§ Coördinaatvolgorde)*
 
-> Bij een WMS 1.3.0 GetMap-request met EPSG:4326 is de coördinaatvolgorde lat/lon (y,x) vanwege de CRS-definitie; voor EPSG:28992 is dat x,y.
+> WFS 2.0 volgt de CRS-definitie voor asvolgorde, tenzij anders geconfigureerd.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — coördinaatvolgorde bbox
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WFS 2.0 — coördinaatvolgorde
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WMS 1.3.0.*
+  - *WFS 2.0 coördinaatvolgorde wordt niet behandeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS 1.3.0 coördinaatvolgorde voor EPSG:4326 en EPSG:28992 wordt niet behandeld in deze bron.*
+  - *WFS 2.0 coördinaatvolgorde wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *WMS 1.3.0 GetMap-requests en coördinaatvolgorde per EPSG-code worden niet behandeld in deze bron.*
+  - *WFS 2.0 coördinaatvolgorde wordt niet besproken in de bron.*
 </details>
 
-### `geo-api-0024` — reference.md:15 *(§ Coördinaatreferentiesystemen (CRS))*
-
-> ETRS89 geografisch (EPSG:4258) is verplicht voor INSPIRE en gebruikt coördinaatvolgorde lat, lon.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** CRS — ETRS89 geografisch INSPIRE
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over ETRS89 geografisch of INSPIRE-verplichtingen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *ETRS89 geografisch (EPSG:4258) en INSPIRE-vereisten worden niet behandeld in deze bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron vermeldt ETRS89 (EPSG:4258) met coördinaatvolgorde latitude, longitude in de CRS-tabel, en noemt INSPIRE in hoofdstuk 4, maar zegt niet expliciet dat ETRS89 geografisch verplicht is voor INSPIRE met de coördinaatvolgorde lat/lon als verplichting.*
-</details>
-
-### `geo-api-0029` — reference.md:61 *(§ WMS 1.3.0 Parameters)*
+### `geo-api-0028` — reference.md:62 *(§ WMS 1.3.0 Parameters)*
 
 > WMS 1.3.0 GetMap vereist de parameters layers, crs, bbox (minx,miny,maxx,maxy), width/height en format.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — GetMap parameters
 
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over WMS 1.3.0 GetMap parameters.*
+  - *WMS 1.3.0 GetMap parameters worden niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS 1.3.0 GetMap parameters worden niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt WMS 1.3.0 niet.*
+  - *De bron behandelt geen WMS 1.3.0 of GetMap parameters. Dit valt buiten de scope van de NLGov REST API Design Rules.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Deze bron gaat over de OGC API Features / REST API Geospatial module. WMS 1.3.0 GetMap parameters worden nergens behandeld.*
 </details>
 
-### `geo-api-0030` — reference.md:61 *(§ WMS 1.3.0 Parameters)*
+### `geo-api-0029` — reference.md:62 *(§ WMS 1.3.0 Parameters)*
 
-> WMS 1.3.0 GetFeatureInfo vereist de parameters layers, crs, bbox, width/height, query_layers en i/j (pixel positie).
+> WMS 1.3.0 GetFeatureInfo vereist de parameters layers, crs, bbox, width/height, query_layers, i/j en info_format.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — GetFeatureInfo parameters
 
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over WMS 1.3.0 GetFeatureInfo parameters.*
+  - *WMS 1.3.0 GetFeatureInfo parameters worden niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WMS 1.3.0 GetFeatureInfo parameters worden niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt WMS 1.3.0 niet.*
+  - *De bron behandelt geen WMS 1.3.0 of GetFeatureInfo parameters. Dit valt buiten de scope van de NLGov REST API Design Rules.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS 1.3.0 GetFeatureInfo wordt niet behandeld in deze bron.*
 </details>
 
-### `geo-api-0031` — reference.md:77 *(§ WFS 2.0 Parameters)*
+### `geo-api-0030` — reference.md:77 *(§ WFS 2.0 Parameters)*
 
-> WFS 2.0 GetFeature vereist de parameter typeName.
+> WFS 2.0 GetFeature vereist de parameter typeName; count, outputFormat, bbox, Filter en sortBy zijn optioneel.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WFS 2.0 — GetFeature parameters
 
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over WFS 2.0 GetFeature parameters.*
+  - *WFS 2.0 GetFeature parameters worden niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WFS 2.0 GetFeature parameters worden niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt WFS 2.0 GetFeature niet.*
+  - *De bron behandelt geen WFS 2.0 of GetFeature parameters. Dit valt buiten de scope van de NLGov REST API Design Rules.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WFS 2.0 GetFeature parameters worden niet behandeld in deze bron.*
 </details>
 
-### `geo-api-0032` — reference.md:77 *(§ WFS 2.0 Parameters)*
+### `geo-api-0031` — reference.md:77 *(§ WFS 2.0 Parameters)*
 
 > WFS 2.0 DescribeFeatureType vereist de parameter typeName.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WFS 2.0 — DescribeFeatureType parameters
 
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over WFS 2.0 DescribeFeatureType parameters.*
+  - *WFS 2.0 DescribeFeatureType parameters worden niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *WFS 2.0 DescribeFeatureType parameters worden niet behandeld in deze ADR-bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron behandelt WFS 2.0 DescribeFeatureType niet.*
+  - *De bron behandelt geen WFS 2.0 of DescribeFeatureType parameters. Dit valt buiten de scope van de NLGov REST API Design Rules.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WFS 2.0 DescribeFeatureType wordt niet behandeld in deze bron.*
 </details>
 
-## GROUNDED — minstens één bron ondersteunt de claim (5)
+## GROUNDED — minstens één bron ondersteunt de claim (9)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `geo-api-0018` — SKILL.md:269 *(§ Veelvoorkomende Problemen)*
+### `geo-api-0001` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> OGC API Features en OGC API Tiles zijn verplicht onder 'pas-toe-of-leg-uit' op forumstandaardisatie.nl.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie — OGC API Features, OGC API Tiles
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Op 19 september 2024 stemde het OBDO in met het verplichten van OGC-API – Features Part 1: Core en Part 2: Coordinate Reference Systems by Reference en OGC-API – Tiles - Part 1: Core door plaatsing op de 'pas toe of leg uit'-lijst
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst bevat alleen navigatie-elementen en categoriekoppen van de pagina (zoals ''Pas toe of leg uit'-standaarden' en 'Aanbevolen standaarden'), maar geen concrete lijst van standaarden. OGC API Features en OGC API Tiles worden nergens genoemd.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/api zonder inhoudelijke informatie over Forum Standaardisatie status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron is de NL GOV REST API Design Rules spec. Forum Standaardisatie-status van OGC API Features of OGC API Tiles wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de inhoud van de GEO module v1.0; Forum Standaardisatie 'pas-toe-of-leg-uit' status voor OGC API Features of OGC API Tiles wordt niet vermeld.*
+</details>
+
+### `geo-api-0002` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> WMS en WFS zijn aanbevolen standaarden op het Forum Standaardisatie (sinds september 2024).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie — WMS, WFS
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Op 19 september 2024 stemde het OBDO in met... het aanbevelen van Nederlands WFS profiel 1.1 op ISO 19142 voor Web Feature Services 2.0, versie 1.1 (WFS) en Nederlands profiel op ISO 19128 Geographic information - Web Map Server Interface (WMS) door plaatsing op de lijst aanbevolen standaarden.
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst bevat geen concrete standaarden of datums. WMS en WFS worden niet vermeld. De pagina toont alleen navigatie en categoriekoppen, niet de daadwerkelijke lijstinhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst bevat geen informatie over WMS/WFS Forum Standaardisatie status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS en WFS worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS en WFS worden niet besproken in de context van Forum Standaardisatie aanbevelingen of statuswijzigingen.*
+</details>
+
+### `geo-api-0014` — SKILL.md:134 *(§ OGC API Features)*
+
+> OGC API Features gebruikt JSON/GeoJSON, een OpenAPI-specificatie en standaard HTTP-methoden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features
+
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > For representing geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [rfc7946]. Support GeoJSON as described in OGC API Features part 4
+  - *De bron bevestigt gebruik van JSON/GeoJSON en OGC API Features. OpenAPI-specificatie en standaard HTTP-methoden worden impliciet beschreven via OGC API Features conformiteit, maar niet expliciet als kenmerken van OGC API Features opgesomd.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst bevat geen inhoudelijke informatie over OGC API Features technische details.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features wordt niet behandeld in deze bron.*
+
+### `geo-api-0016` — SKILL.md:269 *(§ Veelvoorkomende Problemen)*
 
 > PDOK-services zijn open en vereisen geen API-key.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** PDOK — toegang
 
 - **SUPPORTED** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
-  > Nee, iedereen heeft vrij toegang tot de open services en/of downloads van PDOK.
-  - *De bron bevestigt vrije toegang zonder aanmelding. Over een API-key specifiek wordt niet gesproken, maar het principe van vrije toegang zonder credentials is expliciet bevestigd.*
+  > Heb ik een gebruikersnaam en wachtwoord nodig voor het gebruik van PDOK services en/of downloads? Nee, iedereen heeft vrij toegang tot de open services en/of downloads van PDOK.
+  - *De bron bevestigt expliciet dat geen inloggegevens nodig zijn. De claim spreekt over 'API-key' terwijl de bron 'gebruikersnaam en wachtwoord' noemt, maar de strekking is identiek: geen authenticatie vereist.*
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over PDOK-services of API-keys.*
+  - *PDOK-toegang en API-key vereisten worden niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *PDOK-services en API-key vereisten worden niet behandeld in deze bron.*
+  - *PDOK-toegang en API-keys worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *PDOK wordt niet genoemd in de bron.*
+  - *PDOK-services en API-key vereisten worden niet vermeld in de bron.*
 </details>
 
-### `geo-api-0020` — reference.md:11 *(§ Coördinaatreferentiesystemen (CRS))*
+### `geo-api-0018` — reference.md:11 *(§ Belangrijkste CRS-en in Nederland)*
 
-> RD New (Amersfoort) heeft EPSG-code 28992 en gebruikt coördinaatvolgorde x, y (oost, noord) in meters.
+> RD New (Amersfoort) heeft EPSG-code 28992, wordt gebruikt voor Nederlandse kaarten en data, met coördinaatvolgorde x, y (oost, noord) in meters.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — RD New
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > Amersfoort / RD New | 28992 | easting, northing (x, y) | 2D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/28992
-  - *EPSG-code 28992 en coördinaatvolgorde x, y bevestigd. 'In meters' staat niet expliciet in de tabel maar volgt uit de definitie van RD New; de tabel vermeldt easting/northing zonder eenheid.*
+  > Amersfoort / RD New 28992 easting, northing (x, y) 2D Dutch http://www.opengis.net/def/crs/EPSG/9.9.1/28992
+  - *De bron bevestigt EPSG-code 28992, Nederlandse scope, en coördinaatvolgorde x/y. 'In meters' staat niet expliciet maar is inherent aan RD New.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over CRS of EPSG-codes.*
+  - *RD New / EPSG:28992 wordt niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *RD New / EPSG:28992 coördinaatvolgorde wordt niet behandeld in deze bron.*
+  - *RD New (EPSG:28992) wordt niet behandeld in deze bron.*
 
-### `geo-api-0023` — reference.md:14 *(§ Coördinaatreferentiesystemen (CRS))*
+### `geo-api-0021` — reference.md:14 *(§ Belangrijkste CRS-en in Nederland)*
 
-> CRS84 is de OGC API-standaard CRS en gebruikt coördinaatvolgorde lon, lat (lengte, breedte) in graden.
+> CRS84 is het OGC API standaard CRS voor WGS 84 met coördinaatvolgorde lon, lat (lengte, breedte) in graden.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — CRS84
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — CRS84, OGC API Features
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
   > The default CRS for GeoJSON and for OGC API Features is CRS84 (OGC:CRS84), this CRS uses the WGS 84 datum with an ellipsoidal coordinate system in the order longitude-latitude.
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over CRS84 of coördinaatvolgorde.*
+  - *CRS84 wordt niet vermeld in de directory-index.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *CRS84 en coördinaatvolgorde worden niet behandeld in deze bron.*
+  - *CRS84 en OGC API Features standaard CRS worden niet behandeld in deze bron.*
 
-### `geo-api-0028` — reference.md:24 *(§ Coördinaatvolgorde)*
+### `geo-api-0023` — reference.md:19 *(§ Coördinaatvolgorde)*
 
-> GeoJSON (RFC 7946) gebruikt altijd lon/lat in WGS 84.
+> EPSG:4326 en CRS84 verwijzen beide naar WGS 84 maar zijn niet inwisselbaar: EPSG:4326 heeft asvolgorde lat/lon, terwijl CRS84 (OGC:CRS84) lon/lat aanhoudt.
 
-**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** GeoJSON — coördinaatvolgorde
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — EPSG:4326 vs CRS84
 
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7946.txt](https://www.rfc-editor.org/rfc/rfc7946.txt)
-  > The coordinate reference system for all GeoJSON coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] datum, with longitude and latitude units of decimal degrees. [...] The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers.
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > The default CRS for GeoJSON and for OGC API Features is CRS84 (OGC:CRS84), this CRS uses the WGS 84 datum with an ellipsoidal coordinate system in the order longitude-latitude.
+  - *De bron bevestigt impliciet het verschil: CRS84 heeft lon/lat volgorde. Dat EPSG:4326 lat/lon heeft en ze niet inwisselbaar zijn wordt ondersteund door de tabel (CRS84 = longitude-latitude) en de notitie 'Officially, WGS 84 longitude-latitude (OGC:CRS84) is the only CRS allowed in GeoJSON', maar de expliciete vergelijking met EPSG:4326 ontbreekt.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *Het verschil tussen EPSG:4326 en CRS84 wordt niet behandeld in de directory-index.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *Het verschil tussen EPSG:4326 en CRS84 wordt niet behandeld in deze bron.*
 
-### `geo-api-0039` — reference.md:100 *(§ OGC API Features Endpoints)*
+### `geo-api-0026` — reference.md:28 *(§ Coördinaatvolgorde)*
 
-> De standaard CRS voor de `crs` query parameter van OGC API Features is CRS84.
+> OGC API Features gebruikt standaard CRS84 (lon/lat); andere CRS zijn beschikbaar via de `crs` parameter.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — crs parameter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — standaard CRS
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > The default CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. /geo/default-crs: Use CRS84 as the default coordinate reference system (CRS). Support CRS84 in line with OGC API Features Requirement 10.
+  > The default CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. [...] Support the OGC API Features part 2 crs parameter in conformance to the standard.
+  - *De bron bevestigt CRS84 als standaard en de `crs` query parameter voor het specificeren van een alternatief CRS.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
-  - *De brontekst is een directory-index en bevat geen informatie over de crs parameter van OGC API Features.*
+  - *OGC API Features standaard CRS wordt niet behandeld in de directory-index.*
 - **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De standaard CRS voor de `crs` query parameter van OGC API Features wordt niet behandeld in deze ADR-bron.*
+  - *De bron is de NLGov REST API Design Rules 2.1.0. Deze behandelt geen OGC API Features, CRS84, of de `crs` parameter. De geospatiale module wordt enkel kort aangehaald als verwijzing naar een apart document.*
+
+### `geo-api-0027` — reference.md:29 *(§ Coördinaatvolgorde)*
+
+> GeoJSON (RFC 7946) gebruikt altijd lon/lat (WGS 84) als coördinaatvolgorde.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** GeoJSON — RFC 7946
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7946.txt](https://www.rfc-editor.org/rfc/rfc7946.txt)
+  > The coordinate reference system for all GeoJSON coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] datum, with longitude and latitude units of decimal degrees. [...] The first two elements are longitude and latitude, or easting and northing, precisely in that order
+  - *De bron bevestigt zowel WGS 84 als de lon/lat volgorde expliciet. De claim zegt 'altijd', wat overeenkomt met de normatieve tekst die stelt dat dit geldt voor 'all GeoJSON coordinates'.*
 
 </details>

--- a/skills/geo-api/audit.md
+++ b/skills/geo-api/audit.md
@@ -1,0 +1,634 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo-api — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 20 | 51% |
+| CONTRADICTED | 1 | 3% |
+| PARTIALLY_GROUNDED | 5 | 13% |
+| UNGROUNDED | 8 | 21% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 5 | 13% |
+
+*Geverifieerd met sonnet, 7 calls, $0.7463.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (20)
+
+### `geo-api-0003` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> WMS is aanbevolen door het Forum Standaardisatie (sinds september 2024).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS — Forum Standaardisatie status
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WMS of Forum Standaardisatie status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS en Forum Standaardisatie aanbevelingen worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS Forum Standaardisatie status wordt niet behandeld in deze bron.*
+</details>
+
+### `geo-api-0004` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> WFS is aanbevolen door het Forum Standaardisatie (sinds september 2024).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS — Forum Standaardisatie status
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WFS of Forum Standaardisatie status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WFS en Forum Standaardisatie aanbevelingen worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WFS Forum Standaardisatie status wordt niet behandeld in deze bron.*
+</details>
+
+### `geo-api-0005` — SKILL.md:30 *(§ Standaarden Overzicht)*
+
+> OGC API Features heeft Forum-status 'Verplicht'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum-status van standaarden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *Forum-status van OGC API Features wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Forum-status van OGC API Features wordt niet vermeld in de bron.*
+</details>
+
+### `geo-api-0006` — SKILL.md:31 *(§ Standaarden Overzicht)*
+
+> OGC API Tiles heeft Forum-status 'Verplicht'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Tiles — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum-status van standaarden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *Forum-status van OGC API Tiles wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *OGC API Tiles en Forum-status worden niet behandeld in de bron.*
+</details>
+
+### `geo-api-0007` — SKILL.md:32 *(§ Standaarden Overzicht)*
+
+> WMS 1.3.0 heeft Forum-status 'Aanbevolen'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS 1.3.0 — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WMS 1.3.0 Forum-status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *Forum-status van WMS 1.3.0 wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS 1.3.0 Forum-status wordt niet behandeld in de bron.*
+</details>
+
+### `geo-api-0008` — SKILL.md:33 *(§ Standaarden Overzicht)*
+
+> WFS 2.0 heeft Forum-status 'Aanbevolen'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS 2.0 — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WFS 2.0 Forum-status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *Forum-status van WFS 2.0 wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WFS 2.0 Forum-status wordt niet behandeld in de bron.*
+</details>
+
+### `geo-api-0009` — SKILL.md:34 *(§ Standaarden Overzicht)*
+
+> WCS 2.0 heeft geen Forum-status.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WCS 2.0 — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over WCS 2.0 Forum-status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WCS 2.0 en Forum-status worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WCS 2.0 wordt niet genoemd in de bron.*
+</details>
+
+### `geo-api-0010` — SKILL.md:35 *(§ Standaarden Overzicht)*
+
+> GeoPackage 1.3.1 heeft Forum-status 'Verplicht'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoPackage 1.3.1 — standaardenoverzicht
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over GeoPackage Forum-status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *GeoPackage 1.3.1 en Forum-status worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *GeoPackage wordt niet genoemd in de bron.*
+</details>
+
+### `geo-api-0011` — SKILL.md:35 *(§ Standaarden Overzicht)*
+
+> GeoPackage 1.3.1 is een SQLite-gebaseerd bestandsformaat voor lokale opslag van vector- en rasterdata.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoPackage 1.3.1
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van GeoPackage.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *GeoPackage wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *GeoPackage wordt niet behandeld in de bron.*
+</details>
+
+### `geo-api-0012` — SKILL.md:41 *(§ Repositories)*
+
+> De ogc-checker is versie v1.0.4 en is een validatietool van Geonovum voor OGC-services.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker — Geonovum validatietool
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over de ogc-checker tool of versienummers.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De ogc-checker validatietool wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De ogc-checker wordt niet genoemd in de bron.*
+</details>
+
+### `geo-api-0013` — SKILL.md:41 *(§ Repositories)*
+
+> De ogc-checker is gepubliceerd onder de EUPL-1.2 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker — licentie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen licentie-informatie over de ogc-checker.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De ogc-checker licentie wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De ogc-checker en licentie worden niet behandeld in de bron.*
+</details>
+
+### `geo-api-0014` — SKILL.md:48 *(§ WMS (Web Map Service))*
+
+> WMS ondersteunt drie operaties: GetCapabilities, GetMap en GetFeatureInfo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS (Web Map Service)
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van WMS-operaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS-operaties worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS-operaties worden niet beschreven in deze bron.*
+</details>
+
+### `geo-api-0015` — SKILL.md:77 *(§ WFS (Web Feature Service))*
+
+> WFS ondersteunt de operaties GetCapabilities, DescribeFeatureType en GetFeature.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS (Web Feature Service)
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van WFS-operaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WFS-operaties worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WFS-operaties worden niet beschreven in deze bron.*
+</details>
+
+### `geo-api-0021` — reference.md:12 *(§ Coördinaatreferentiesystemen (CRS))*
+
+> ETRS89 / UTM zone 31N heeft EPSG-code 25831 en wordt gebruikt voor INSPIRE en Europese data.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — ETRS89 UTM 31N
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over ETRS89 UTM 31N of INSPIRE.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *ETRS89 UTM 31N / EPSG:25831 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *ETRS89 / UTM zone 31N (EPSG:25831) wordt niet vermeld in de bron. De bron noemt ETRS89 (EPSG:4258 en 4937) maar niet UTM zone 31N.*
+</details>
+
+### `geo-api-0026` — reference.md:22 *(§ Coördinaatvolgorde)*
+
+> WFS 2.0 volgt de CRS-definitie voor coördinaatvolgorde, tenzij anders geconfigureerd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WFS 2.0 — coördinaatvolgorde
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WFS 2.0.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron beschrijft de NLGov REST API Design Rules (ADR v2.1.0). WFS 2.0 coördinaatvolgorde wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt WFS 2.0 niet; de bron gaat uitsluitend over de API Design Rules Module Geospatial en OGC API Features.*
+</details>
+
+### `geo-api-0033` — reference.md:88 *(§ OGC API Features Endpoints)*
+
+> OGC API Features biedt het endpoint `/conformance` (GET) voor conformance classes.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron verwijst naar OGC API Features maar noemt het /conformance endpoint niet expliciet. Alleen /collections en /crss worden als voorbeeldendpoints genoemd.*
+</details>
+
+### `geo-api-0034` — reference.md:92 *(§ OGC API Features Endpoints)*
+
+> OGC API Features biedt het endpoint `/collections/{id}/items` (GET) voor features in GeoJSON-formaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron verwijst naar OGC API Features collecties en items (bijv. /collections/gebouwen/items) in voorbeelden, maar specificeert het endpoint /collections/{id}/items niet als formeel endpoint met de eigenschap 'GeoJSON-formaat'. Het wordt impliciet gebruikt in voorbeelden maar niet als formele specificatie van het endpoint beschreven.*
+</details>
+
+### `geo-api-0035` — reference.md:94 *(§ OGC API Features Endpoints)*
+
+> OGC API Features biedt het endpoint `/api` (GET) voor de OpenAPI specificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — endpoints
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over OGC API Features endpoints.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features endpoints worden niet beschreven in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron noemt het /api endpoint voor de OpenAPI specificatie niet.*
+</details>
+
+### `geo-api-0036` — reference.md:97 *(§ OGC API Features Endpoints)*
+
+> De `limit` query parameter voor OGC API Features `/items` heeft een standaardwaarde van 10; het maximum verschilt per service.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — query parameters
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over query parameters van OGC API Features.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De `limit` query parameter voor OGC API Features wordt niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt de `limit` query parameter en de standaardwaarde van 10 niet.*
+</details>
+
+### `geo-api-0038` — reference.md:99 *(§ OGC API Features Endpoints)*
+
+> De `datetime` query parameter voor OGC API Features `/items` gebruikt ISO 8601 formaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — datetime parameter
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over de datetime parameter van OGC API Features.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De `datetime` query parameter voor OGC API Features wordt niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt de `datetime` query parameter niet.*
+</details>
+
+## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
+
+### `geo-api-0022` — reference.md:13 *(§ Coördinaatreferentiesystemen (CRS))*
+
+> WGS 84 heeft EPSG-code 4326 en coördinaatvolgorde lat, lon (breedte, lengte) in graden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — WGS 84
+
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > WGS 84 longitude-latitude | CRS84 | longitude, latitude (λ, φ) | 2D | Global | http://www.opengis.net/def/crs/OGC/1.3/CRS84
+  - *De bron geeft WGS 84 longitude-latitude de naam CRS84 met coördinaatvolgorde lon, lat, niet EPSG:4326. EPSG:4326 wordt niet als apart item vermeld in de CRS-tabel. De claim dat WGS 84 EPSG-code 4326 heeft en lat/lon volgorde kent is daarmee strijdig met hoe de bron WGS 84 / CRS84 presenteert (lon, lat volgorde).*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over WGS 84 of EPSG:4326.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WGS 84 / EPSG:4326 coördinaatvolgorde wordt niet behandeld in deze bron.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (5)
+
+### `geo-api-0016` — SKILL.md:134 *(§ OGC API Features)*
+
+> OGC API Features is de REST-gebaseerde opvolger van WFS en gebruikt JSON/GeoJSON, een OpenAPI-specificatie en standaard HTTP-methoden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Support GeoJSON as described in OGC API Features Requirements class 8.3 [...] Support GeoJSON as described in OGC API Features part 4 [...] Note The Geospatial Module is focused on JSON-based encoding of data.
+  - *De bron bevestigt dat OGC API Features JSON/GeoJSON en een OpenAPI-specificatie gebruikt en verwijst naar OGC API Features standaarden, maar beschrijft OGC API Features niet expliciet als 'de REST-gebaseerde opvolger van WFS' en noemt 'standaard HTTP-methoden' niet expliciet in die context.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke beschrijving van OGC API Features.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features als opvolger van WFS wordt niet beschreven in deze bron. De bron verwijst alleen naar de geospatial module via /core/geospatial maar beschrijft OGC API Features zelf niet.*
+
+### `geo-api-0019` — SKILL.md:270 *(§ Veelvoorkomende Problemen)*
+
+> OGC API Features geeft HTML terug als er geen Accept-header wordt meegegeven; de correcte header is `Accept: application/geo+json`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OGC API Features — Accept-header
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Note The Geospatial Module is focused on JSON-based encoding of data. However, consider also supporting text/html, as recommended in OGC API Features [ogcapi-features-1]. Sharing data on the Web should include publication in HTML, as this allows discovery of the data through common search engines as well as viewing the data directly in a browser.
+  - *De bron bevestigt dat HTML ondersteund wordt en dat application/geo+json de media type is voor geospatiale responses, maar zegt niet expliciet dat HTML de default is bij ontbrekende Accept-header.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over Accept-headers bij OGC API Features.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *OGC API Features Accept-header gedrag wordt niet beschreven in deze bron.*
+
+### `geo-api-0025` — reference.md:21 *(§ Coördinaatvolgorde)*
+
+> WMS 1.3.0 volgt de CRS-definitie voor coördinaatvolgorde: voor EPSG:4326 is dat lat/lon (y,x), voor EPSG:28992 is dat x,y.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WMS 1.3.0 — coördinaatvolgorde
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > ETRS89 | 4258 | latitude, longitude (φ, λ) | 2D | European [...] Amersfoort / RD New | 28992 | easting, northing (x, y) | 2D | Dutch
+  - *De CRS-tabel bevestigt lat/lon voor EPSG:4258 en x/y voor EPSG:28992. De bron zegt echter niet expliciet dat dit het gevolg is van de WMS 1.3.0 specificatie of een WMS GetMap-context; het is een algemene CRS-tabel zonder WMS-specifieke context.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WMS 1.3.0.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS 1.3.0 coördinaatvolgorde per CRS wordt niet behandeld in deze bron.*
+
+### `geo-api-0027` — reference.md:23 *(§ Coördinaatvolgorde)*
+
+> OGC API Features gebruikt standaard CRS84 (lon/lat); andere CRS zijn opvraagbaar via de `crs` parameter.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — standaard CRS
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > The default CRS for GeoJSON and for OGC API Features is CRS84 (OGC:CRS84), this CRS uses the WGS 84 datum with an ellipsoidal coordinate system in the order longitude-latitude.
+  - *De bron bevestigt CRS84 als standaard, en vermeldt de `crs` parameter (/geo/crs-query-parameter). Echter, de bron noemt de `crs` parameter als een header-mechanisme (Content-Crs) én als query parameter apart — het 'opvraagbaar via de crs parameter' klopt, maar de bron legt ook uit dat andere CRS via bbox-crs en filter-crs beschikbaar zijn. Het woordje 'andere CRS zijn opvraagbaar via de crs parameter' is slechts gedeeltelijk gedekt.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over standaard CRS bij OGC API Features.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron behandelt de NLGov REST API Design Rules. OGC API Features standaard CRS en crs parameter specificaties vallen buiten de scope van deze bron.*
+
+### `geo-api-0037` — reference.md:98 *(§ OGC API Features Endpoints)*
+
+> De `bbox` query parameter voor OGC API Features `/items` heeft de volgorde lon_min,lat_min,lon_max,lat_max.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — bbox parameter
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Support the OGC API Features part 1 bbox query parameter in conformance to the standard. Example: GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2
+  - *Het voorbeeld toont lon_min,lat_min,lon_max,lat_max volgorde (5.4,52.1,5.5,53.2) wat overeenkomt met de claim, maar de bron specificeert de volgorde niet expliciet als definitie — het verwijst naar OGC API Features part 1 als de standaard. De volgorde is impliciet af te leiden uit het voorbeeld.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over de bbox parameter van OGC API Features.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De `bbox` query parameter volgorde voor OGC API Features wordt niet behandeld in deze ADR-bron.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (8)
+
+### `geo-api-0001` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> OGC API Features is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OGC API Features — Forum Standaardisatie status
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/api en bevat geen inhoudelijke informatie over Forum Standaardisatie status van standaarden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron is de NLGov REST API Design Rules 2.1.0 specificatie. OGC API Features en Forum Standaardisatie 'pas-toe-of-leg-uit' status worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de inhoud van de Geospatial Module (ADR), niet de Forum Standaardisatie status van OGC API Features.*
+</details>
+
+### `geo-api-0002` — SKILL.md:22 *(§ OGC API Services & Kaartdiensten)*
+
+> OGC API Tiles is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OGC API Tiles — Forum Standaardisatie status
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over Forum Standaardisatie status.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron behandelt OGC API Tiles noch Forum Standaardisatie verplichtingen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *OGC API Tiles wordt in de bron niet genoemd, en Forum Standaardisatie status staat niet in de bron.*
+</details>
+
+### `geo-api-0017` — SKILL.md:266 *(§ Veelvoorkomende Problemen)*
+
+> Bij een WMS 1.3.0 GetMap-request met EPSG:4326 is de coördinaatvolgorde lat/lon (y,x) vanwege de CRS-definitie; voor EPSG:28992 is dat x,y.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — coördinaatvolgorde bbox
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over coördinaatvolgorde bij WMS 1.3.0.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS 1.3.0 coördinaatvolgorde voor EPSG:4326 en EPSG:28992 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *WMS 1.3.0 GetMap-requests en coördinaatvolgorde per EPSG-code worden niet behandeld in deze bron.*
+</details>
+
+### `geo-api-0024` — reference.md:15 *(§ Coördinaatreferentiesystemen (CRS))*
+
+> ETRS89 geografisch (EPSG:4258) is verplicht voor INSPIRE en gebruikt coördinaatvolgorde lat, lon.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** CRS — ETRS89 geografisch INSPIRE
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over ETRS89 geografisch of INSPIRE-verplichtingen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *ETRS89 geografisch (EPSG:4258) en INSPIRE-vereisten worden niet behandeld in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron vermeldt ETRS89 (EPSG:4258) met coördinaatvolgorde latitude, longitude in de CRS-tabel, en noemt INSPIRE in hoofdstuk 4, maar zegt niet expliciet dat ETRS89 geografisch verplicht is voor INSPIRE met de coördinaatvolgorde lat/lon als verplichting.*
+</details>
+
+### `geo-api-0029` — reference.md:61 *(§ WMS 1.3.0 Parameters)*
+
+> WMS 1.3.0 GetMap vereist de parameters layers, crs, bbox (minx,miny,maxx,maxy), width/height en format.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — GetMap parameters
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over WMS 1.3.0 GetMap parameters.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS 1.3.0 GetMap parameters worden niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt WMS 1.3.0 niet.*
+</details>
+
+### `geo-api-0030` — reference.md:61 *(§ WMS 1.3.0 Parameters)*
+
+> WMS 1.3.0 GetFeatureInfo vereist de parameters layers, crs, bbox, width/height, query_layers en i/j (pixel positie).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WMS 1.3.0 — GetFeatureInfo parameters
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over WMS 1.3.0 GetFeatureInfo parameters.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WMS 1.3.0 GetFeatureInfo parameters worden niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt WMS 1.3.0 niet.*
+</details>
+
+### `geo-api-0031` — reference.md:77 *(§ WFS 2.0 Parameters)*
+
+> WFS 2.0 GetFeature vereist de parameter typeName.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WFS 2.0 — GetFeature parameters
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over WFS 2.0 GetFeature parameters.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WFS 2.0 GetFeature parameters worden niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt WFS 2.0 GetFeature niet.*
+</details>
+
+### `geo-api-0032` — reference.md:77 *(§ WFS 2.0 Parameters)*
+
+> WFS 2.0 DescribeFeatureType vereist de parameter typeName.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WFS 2.0 — DescribeFeatureType parameters
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over WFS 2.0 DescribeFeatureType parameters.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *WFS 2.0 DescribeFeatureType parameters worden niet behandeld in deze ADR-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt WFS 2.0 DescribeFeatureType niet.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (5)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-api-0018` — SKILL.md:269 *(§ Veelvoorkomende Problemen)*
+
+> PDOK-services zijn open en vereisen geen API-key.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** PDOK — toegang
+
+- **SUPPORTED** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  > Nee, iedereen heeft vrij toegang tot de open services en/of downloads van PDOK.
+  - *De bron bevestigt vrije toegang zonder aanmelding. Over een API-key specifiek wordt niet gesproken, maar het principe van vrije toegang zonder credentials is expliciet bevestigd.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over PDOK-services of API-keys.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *PDOK-services en API-key vereisten worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *PDOK wordt niet genoemd in de bron.*
+</details>
+
+### `geo-api-0020` — reference.md:11 *(§ Coördinaatreferentiesystemen (CRS))*
+
+> RD New (Amersfoort) heeft EPSG-code 28992 en gebruikt coördinaatvolgorde x, y (oost, noord) in meters.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — RD New
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Amersfoort / RD New | 28992 | easting, northing (x, y) | 2D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/28992
+  - *EPSG-code 28992 en coördinaatvolgorde x, y bevestigd. 'In meters' staat niet expliciet in de tabel maar volgt uit de definitie van RD New; de tabel vermeldt easting/northing zonder eenheid.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over CRS of EPSG-codes.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *RD New / EPSG:28992 coördinaatvolgorde wordt niet behandeld in deze bron.*
+
+### `geo-api-0023` — reference.md:14 *(§ Coördinaatreferentiesystemen (CRS))*
+
+> CRS84 is de OGC API-standaard CRS en gebruikt coördinaatvolgorde lon, lat (lengte, breedte) in graden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CRS — CRS84
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > The default CRS for GeoJSON and for OGC API Features is CRS84 (OGC:CRS84), this CRS uses the WGS 84 datum with an ellipsoidal coordinate system in the order longitude-latitude.
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over CRS84 of coördinaatvolgorde.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *CRS84 en coördinaatvolgorde worden niet behandeld in deze bron.*
+
+### `geo-api-0028` — reference.md:24 *(§ Coördinaatvolgorde)*
+
+> GeoJSON (RFC 7946) gebruikt altijd lon/lat in WGS 84.
+
+**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** GeoJSON — coördinaatvolgorde
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7946.txt](https://www.rfc-editor.org/rfc/rfc7946.txt)
+  > The coordinate reference system for all GeoJSON coordinates is a geographic coordinate reference system, using the World Geodetic System 1984 (WGS 84) [WGS84] datum, with longitude and latitude units of decimal degrees. [...] The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers.
+
+### `geo-api-0039` — reference.md:100 *(§ OGC API Features Endpoints)*
+
+> De standaard CRS voor de `crs` query parameter van OGC API Features is CRS84.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OGC API Features — crs parameter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > The default CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. /geo/default-crs: Use CRS84 as the default coordinate reference system (CRS). Support CRS84 in line with OGC API Features Requirement 10.
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/api/](https://docs.geostandaarden.nl/api/)
+  - *De brontekst is een directory-index en bevat geen informatie over de crs parameter van OGC API Features.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De standaard CRS voor de `crs` query parameter van OGC API Features wordt niet behandeld in deze ADR-bron.*
+
+</details>

--- a/skills/geo-inspire/audit.md
+++ b/skills/geo-inspire/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo-inspire — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,161 +7,128 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 13 | 45% |
+| UNSUPPORTED_ASSERTION | 10 | 34% |
 | CONTRADICTED | 0 | 0% |
 | PARTIALLY_GROUNDED | 2 | 7% |
-| UNGROUNDED | 14 | 48% |
+| UNGROUNDED | 17 | 59% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
 | GROUNDED | 0 | 0% |
 
-*Geverifieerd met sonnet, 3 calls, $0.4661.*
+*Geverifieerd met sonnet, 4 calls, $0.5022.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (10)
 
 ### `geo-inspire-0002` — SKILL.md:28 *(§ Standaarden Overzicht)*
 
-> INSPIRE view services gebruiken WMS 1.3.0 of WMTS 1.0.0 als standaard.
+> INSPIRE view services gebruiken WMS 1.3.0 of WMTS 1.0.0 als standaard voor het bekijken van kaartafbeeldingen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE view services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *De brontekst is een overzichtspagina van handreikingen. Technische details over WMS/WMTS versies worden niet vermeld.*
+  - *De brontekst bevat alleen een overzicht van handreikingen (INSPIRE, EU datawetgeving, Data Spaces, HVD). Technische details over WMS/WMTS zijn niet aanwezig.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
   - *De brontekst is de homepage van de INSPIRE Knowledge Base en bevat geen technische details over view services of WMS/WMTS standaarden.*
 
 ### `geo-inspire-0003` — SKILL.md:29 *(§ Standaarden Overzicht)*
 
-> INSPIRE download services gebruiken WFS 2.0, Atom of OGC API Features als standaard.
+> INSPIRE download services gebruiken WFS 2.0, Atom of OGC API Features als standaard voor het downloaden van data.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE download services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *De brontekst bevat geen informatie over WFS, Atom of OGC API Features als standaard voor download services.*
+  - *Geen technische details over download services in deze brontekst.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over download services of WFS/Atom/OGC API Features.*
+  - *De brontekst bevat geen informatie over download services of WFS/Atom/OGC API Features standaarden.*
 
 ### `geo-inspire-0004` — SKILL.md:30 *(§ Standaarden Overzicht)*
 
-> INSPIRE discovery services gebruiken CSW 2.0.2 als standaard.
+> INSPIRE discovery services gebruiken CSW 2.0.2 als standaard voor het zoeken van metadata.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE discovery services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *CSW 2.0.2 wordt niet genoemd in de brontekst.*
+  - *Geen vermelding van CSW 2.0.2 of discovery services technische standaarden.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over discovery services of CSW.*
+  - *De brontekst bevat geen informatie over discovery services of CSW 2.0.2.*
 
 ### `geo-inspire-0005` — SKILL.md:31 *(§ Standaarden Overzicht)*
 
-> INSPIRE data-encoding gebruikt GML 3.2.1 voor geo-data uitwisseling.
+> INSPIRE data-encoding gebruikt GML 3.2.1 voor het uitwisselen van geo-data.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE data-encoding
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *GML 3.2.1 wordt niet genoemd in de brontekst.*
+  - *Geen vermelding van GML 3.2.1 of data-encoding in deze brontekst.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over data-encoding of GML.*
+  - *De brontekst bevat geen informatie over GML 3.2.1 of data-encoding.*
 
 ### `geo-inspire-0006` — SKILL.md:32 *(§ Standaarden Overzicht)*
 
-> INSPIRE metadata gebruikt ISO 19115/19119 als standaard voor beschrijving van data en services.
+> INSPIRE metadata gebruikt ISO 19115/19119 voor beschrijving van data en services.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *ISO 19115/19119 wordt niet genoemd in de brontekst.*
+  - *Geen vermelding van ISO 19115/19119 metadata-standaarden.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over metadata standaarden zoals ISO 19115/19119.*
+  - *De brontekst bevat geen informatie over ISO 19115/19119 of metadata-standaarden.*
 
-### `geo-inspire-0007` — SKILL.md:43 *(§ INSPIRE Data Thema's)*
+### `geo-inspire-0012` — SKILL.md:128 *(§ Download Service (WFS / Atom / OGC API Features))*
 
-> INSPIRE Annex I referentiedata is van toepassing sinds 2010.
+> INSPIRE download services kunnen op drie manieren geïmplementeerd worden: WFS 2.0, Atom feed, of OGC API Features.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Annex I
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE download services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Geen informatie over INSPIRE Annex I of toepassingsdatum 2010 in de brontekst.*
+  - *Geen technische details over implementatiewijzen van download services.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over implementatiedata van Annex I.*
+  - *De brontekst bevat geen informatie over implementatieopties voor download services.*
 
-### `geo-inspire-0008` — SKILL.md:57 *(§ INSPIRE Data Thema's)*
+### `geo-inspire-0013` — SKILL.md:150 *(§ Discovery Service (CSW))*
 
-> INSPIRE Annex II (fysisch milieu) en Annex III (milieu en maatschappij) zijn van toepassing sinds 2013.
+> De Nederlandse INSPIRE discovery service is het Nationaal Georegister (NGR).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Annex II en III
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE discovery service Nederland
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Annex II en III en de datum 2013 worden niet vermeld in de brontekst.*
+  - *Geen vermelding van het Nationaal Georegister (NGR) als discovery service.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over Annex II of III en hun toepassingsdatum.*
+  - *De brontekst bevat geen informatie over het Nationaal Georegister of de Nederlandse discovery service.*
 
-### `geo-inspire-0014` — SKILL.md:150 *(§ Discovery Service (CSW))*
-
-> De Nederlandse INSPIRE discovery service is het Nationaal Georegister (NGR) op nationaalgeoregister.nl.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE discovery services Nederland
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Het Nationaal Georegister of nationaalgeoregister.nl wordt niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over de Nederlandse discovery service of nationaalgeoregister.nl.*
-
-### `geo-inspire-0016` — SKILL.md:214 *(§ Monitoring en Rapportage)*
+### `geo-inspire-0015` — SKILL.md:214 *(§ Monitoring en Rapportage)*
 
 > Nederland rapporteert jaarlijks aan de EU over INSPIRE-implementatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE monitoring en rapportage Nederland
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE monitoring Nederland
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Jaarlijkse rapportage aan de EU over INSPIRE-implementatie wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van jaarlijkse rapportage aan de EU over INSPIRE-implementatie.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over Nederlandse rapportage aan de EU.*
+  - *De brontekst bevat geen informatie over jaarlijkse Nederlandse rapportage aan de EU.*
 
-### `geo-inspire-0017` — SKILL.md:228 *(§ Veelvoorkomende Problemen)*
+### `geo-inspire-0016` — SKILL.md:228 *(§ Veelvoorkomende Problemen)*
 
-> OGC API Features is erkend als INSPIRE Good Practice voor download services.
+> OGC API Features is inmiddels erkend als INSPIRE Good Practice voor download services.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE download services / OGC API Features
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *OGC API Features als INSPIRE Good Practice wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van OGC API Features als INSPIRE Good Practice.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over OGC API Features als Good Practice.*
+  - *De brontekst bevat geen informatie over OGC API Features als Good Practice voor download services.*
 
-### `geo-inspire-0022` — reference.md:118 *(§ Monitoring en Rapportage)*
+### `geo-inspire-0024` — reference.md:169 *(§ Lokale Validatie met ETF)*
 
-> INSPIRE monitoring indicator MDi1 meet metadata beschikbaarheid met een doel van 100%.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE jaarlijkse monitoring indicatoren
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *INSPIRE monitoring indicator MDi1 wordt niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over monitoring indicatoren zoals MDi1.*
-
-### `geo-inspire-0023` — reference.md:126 *(§ Monitoring en Rapportage)*
-
-> INSPIRE monitoring indicator NSi4 meet services beschikbaarheid (uptime) met een doel van ≥99%.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE jaarlijkse monitoring indicatoren
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *INSPIRE monitoring indicator NSi4 wordt niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over monitoring indicator NSi4 of uptime-doelstellingen.*
-
-### `geo-inspire-0024` — reference.md:169 *(§ INSPIRE Validator Details)*
-
-> De INSPIRE Validator is gebaseerd op het ETF testing framework (etf-validator/etf-webapp op GitHub).
+> De INSPIRE Validator is gebaseerd op het ETF testing framework (etf-validator/etf-webapp).
 
 **Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Validator / ETF
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *ETF testing framework en GitHub-repository worden niet vermeld in de brontekst.*
+  - *Geen vermelding van ETF testing framework of etf-validator/etf-webapp.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst vermeldt de INSPIRE Validator maar geeft geen technische details over het ETF framework of de GitHub-repository.*
+  - *De brontekst noemt de INSPIRE Validator maar vermeldt het ETF testing framework of etf-validator/etf-webapp niet.*
 
 ## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
 
@@ -172,173 +139,208 @@
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE-richtlijn 2007/2/EG
 
 - **PARTIALLY_SUPPORTED** (high) — [https://docs.geostandaarden.nl/eu/INSPIRE-handreiking](https://docs.geostandaarden.nl/eu/INSPIRE-handreiking)
-  > INSPIRE zorgt voor een hoge mate van interoperabiliteit door per thema een standaard dataspecificatie te beschrijven die door alle lidstaten geïmplementeerd moet worden. [...] Datasets en -services die onder één van de 34 INSPIRE-thema's vallen, moeten te vinden, raadplegen en downloaden zijn.
-  - *De bron bevestigt de 34 thema's, de interoperabiliteitsverplichting en de vereiste view-, download- en discovery-services. Echter: de discovery-service wordt in de claim niet expliciet als derde service genoemd (de claim noemt 'view-, download- en discovery-services'), terwijl de bron wel alle drie beschrijft. Verder is de claim technisch juist maar de bron stelt ook dat de INSPIRE-richtlijn zelf (2007/2/EG) dit oplegt via implementing rules en verordeningen — de directe koppeling aan het richtlijnnummer 2007/2/EG wordt in de bron alleen indirect bevestigd (via verwijzingen naar de verordening). De kern van de claim wordt ondersteund, maar de exacte formulering 'verplicht lidstaten' via de richtlijn zelf wordt niet letterlijk bevestigd; de bron spreekt van eisen uit implementing rules en verordeningen.*
+  > In het kader van INSPIRE realiseren de Europese lidstaten een digitaal netwerk voor het uitwisselen van gegevens over de leefomgeving. [...] Datasets en -services die onder één van de 34 INSPIRE-thema's vallen, moeten te vinden, raadplegen en downloaden zijn.
+  - *De bron bevestigt de 34 thema's, de interoperabiliteitsverplichting en de vereiste view- en downloadservices. De discovery-service wordt in de bron ook beschreven (NGR als Discovery Service). Echter, de claim stelt dat de richtlijn dit 'verplicht' via al deze services als één geïntegreerde verplichting — de bron beschrijft dit als implementatievereisten maar citeert de richtlijn (2007/2/EG) zelf niet letterlijk met de exacte formulering 'verplicht lidstaten'. De interoperabiliteitsverplichting is in de bron gekoppeld aan de uitvoeringsverordening (EU) Nr. 1089/2010, niet direct aan de richtlijn 2007/2/EG zelf. Vandaar PARTIALLY_SUPPORTED.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De aangeleverde brontekst is de navigatiepagina van forumstandaardisatie.nl/open-standaarden. Deze bevat geen inhoudelijke informatie over de INSPIRE-richtlijn, ruimtelijke data, thema's, of view-/download-/discovery-services. De tekst bestaat uitsluitend uit navigatie-elementen, menu-items en links.*
 
-### `geo-inspire-0015` — SKILL.md:162 *(§ INSPIRE Validatie)*
+### `geo-inspire-0014` — SKILL.md:162 *(§ INSPIRE Validatie)*
 
-> De INSPIRE Validator is gebaseerd op het ETF testing framework en beschikbaar via inspire.ec.europa.eu/validator/.
+> De INSPIRE Validator is gebaseerd op het ETF-framework en toetst services en data op conformiteit.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE validatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Validator
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  > Discontinuation of the INSPIRE Reference Validator After almost ten years since its introduction, the INSPIRE Reference Validator was discontinued on April 1st, 2026.
-  - *De brontekst bevestigt het bestaan van de INSPIRE Reference Validator en dat deze beschikbaar was via inspire.ec.europa.eu, maar vermeldt niets over het ETF testing framework of het specifieke URL-pad /validator/. Bovendien is de validator per 1 april 2026 stopgezet, wat de claim dat hij 'beschikbaar via' is tegenspreekt in de huidige toestand — maar de claim zelf is historisch juist.*
+- **PARTIALLY_SUPPORTED** (low) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  > After almost ten years since its introduction, the INSPIRE Reference Validator was discontinued on April 1st, 2026. The Validator has been a crucial tool for INSPIRE implementers to test the compliance of their metadata, spatial datasets, and services.
+  - *De bron bevestigt het bestaan van de INSPIRE Validator en diens functie (compliance testen), maar noemt het ETF-framework niet.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *De INSPIRE Validator en het ETF testing framework worden niet vermeld in de brontekst.*
+  - *Geen vermelding van de INSPIRE Validator of ETF-framework in deze brontekst.*
 
-## UNGROUNDED — geen bron ondersteunt de claim (14)
+## UNGROUNDED — geen bron ondersteunt de claim (17)
 
-### `geo-inspire-0009` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+### `geo-inspire-0007` — SKILL.md:97 *(§ View Service (WMS/WMTS))*
 
 > INSPIRE view services moeten voldoen aan WMS 1.3.0 of WMTS 1.0.0.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Geen technische vereisten voor view services in de brontekst.*
+  - *Geen technische vereisten voor view services in deze brontekst.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
   - *De brontekst bevat geen technische vereisten voor view services.*
 
-### `geo-inspire-0010` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+### `geo-inspire-0008` — SKILL.md:98 *(§ View Service (WMS/WMTS))*
 
-> INSPIRE view services moeten INSPIRE Extended Capabilities bevatten in de GetCapabilities response.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *INSPIRE Extended Capabilities wordt niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over INSPIRE Extended Capabilities.*
-
-### `geo-inspire-0011` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
-
-> INSPIRE view services moeten ondersteuning bieden voor EPSG:4258 (ETRS89) en optioneel EPSG:3035 (ETRS89-LAEA).
+> INSPIRE view services moeten INSPIRE Extended Capabilities bevatten in de GetCapabilities-response.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *EPSG:4258 en EPSG:3035 worden niet vermeld in de brontekst.*
+  - *Geen vermelding van INSPIRE Extended Capabilities of GetCapabilities.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over CRS-vereisten voor view services.*
+  - *De brontekst bevat geen informatie over INSPIRE Extended Capabilities of GetCapabilities-responses.*
 
-### `geo-inspire-0012` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+### `geo-inspire-0009` — SKILL.md:99 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten EPSG:4258 (ETRS89) ondersteunen en optioneel EPSG:3035 (ETRS89-LAEA).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen vermelding van EPSG:4258 of EPSG:3035 in deze brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over EPSG:4258 of CRS-vereisten voor view services.*
+
+### `geo-inspire-0010` — SKILL.md:100 *(§ View Service (WMS/WMTS))*
 
 > INSPIRE view services moeten meertalige ondersteuning bieden, minimaal Engels en Nederlands.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Meertalige ondersteuning voor view services wordt niet besproken in de brontekst.*
+  - *Geen vermelding van meertalige ondersteuningsvereisten.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over meertalige vereisten voor view services.*
+  - *De brontekst bevat geen informatie over meertalige ondersteuning voor view services.*
 
-### `geo-inspire-0013` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+### `geo-inspire-0011` — SKILL.md:101 *(§ View Service (WMS/WMTS))*
 
-> INSPIRE view services moeten specifieke laagnamen conform INSPIRE data specificaties hanteren.
+> INSPIRE view services moeten specifieke laagnamen conform INSPIRE data specificaties gebruiken.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Laagnamen conform INSPIRE data specificaties worden niet vermeld in de brontekst.*
+  - *Geen vermelding van laagnamen of INSPIRE data specificaties voor view services.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over laagnamen in view services.*
+  - *De brontekst bevat geen informatie over laagnamen of INSPIRE data specificaties voor view services.*
 
-### `geo-inspire-0018` — reference.md:43 *(§ Transformatieregels)*
+### `geo-inspire-0017` — reference.md:43 *(§ Transformatieregels)*
 
 > NEN3610ID wordt bij INSPIRE-transformatie vertaald naar INSPIRE `inspireId` (namespace + localId + versionId).
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels identificatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *NEN3610ID en INSPIRE inspireId worden niet vermeld in de brontekst.*
+  - *Geen vermelding van NEN3610ID of INSPIRE inspireId transformatieregels.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over NEN3610ID of INSPIRE inspireId transformaties.*
+  - *De brontekst bevat geen informatie over NEN3610ID of inspireId transformatieregels.*
 
-### `geo-inspire-0019` — reference.md:44 *(§ Transformatieregels)*
+### `geo-inspire-0018` — reference.md:44 *(§ Transformatieregels)*
 
 > Bij INSPIRE-transformatie moet geometrie getransformeerd worden van EPSG:28992 (RD New) naar EPSG:4258 (ETRS89).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels geometrie/CRS
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels CRS
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Geometrietransformatie van EPSG:28992 naar EPSG:4258 wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van EPSG:28992 (RD New) naar EPSG:4258 transformatie.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over geometrietransformaties of CRS-conversies.*
+  - *De brontekst bevat geen informatie over EPSG:28992 of geometrietransformaties.*
 
-### `geo-inspire-0020` — reference.md:45 *(§ Transformatieregels)*
+### `geo-inspire-0019` — reference.md:45 *(§ Transformatieregels)*
 
 > Bij INSPIRE-transformatie worden NL-waarden gemapped naar INSPIRE codelijsten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels codelijsten
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Mapping van NL-waarden naar INSPIRE codelijsten wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van codelijst-mapping bij INSPIRE-transformatie.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over codelijst-mapping bij INSPIRE-transformatie.*
+  - *De brontekst bevat geen informatie over codelijstmapping bij INSPIRE-transformatie.*
 
-### `geo-inspire-0021` — reference.md:46 *(§ Transformatieregels)*
+### `geo-inspire-0020` — reference.md:46 *(§ Transformatieregels)*
 
 > Bij INSPIRE-transformatie worden beginGeldigheid/eindGeldigheid vertaald naar het INSPIRE temporeel model.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels temporele attributen
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *BeginGeldigheid/eindGeldigheid en INSPIRE temporeel model worden niet vermeld in de brontekst.*
+  - *Geen vermelding van temporele attributen of beginGeldigheid/eindGeldigheid in transformatieregels.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
   - *De brontekst bevat geen informatie over temporele attributen of beginGeldigheid/eindGeldigheid.*
+
+### `geo-inspire-0021` — reference.md:99 *(§ CRS Transformatie)*
+
+> Bij INSPIRE-data moet de geometrie in EPSG:4258 (ETRS89) staan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE CRS-vereiste
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen vermelding van CRS-vereisten voor INSPIRE-data.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen CRS-vereisten voor INSPIRE-data.*
+
+### `geo-inspire-0022` — reference.md:126 *(§ Jaarlijkse Monitoring Indicatoren)*
+
+> De INSPIRE monitoring indicator NSi4 vereist een services beschikbaarheid (uptime) van ≥99%.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE monitoring rapportage
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen vermelding van NSi4 of uptime-vereisten in monitoring.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over monitoring indicator NSi4 of uptime-vereisten.*
+
+### `geo-inspire-0023` — reference.md:117 *(§ Jaarlijkse Monitoring Indicatoren)*
+
+> De INSPIRE monitoring indicatoren MDi1, MDi2, DSi1, DSi2, DSi3, NSi1, NSi2, NSi3 hebben alle een doel van 100%.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE monitoring rapportage
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen vermelding van monitoring indicatoren MDi1, MDi2, DSi1 etc. in deze brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over monitoring indicatoren MDi1, MDi2, DSi1 etc.*
 
 ### `geo-inspire-0025` — reference.md:184 *(§ INSPIRE en OGC API Features)*
 
 > OGC API Features als INSPIRE download service vereist een landingspagina met INSPIRE metadata-link.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features download service
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Vereisten voor OGC API Features landingspagina worden niet vermeld in de brontekst.*
+  - *Geen technische vereisten voor OGC API Features als INSPIRE download service.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen technische vereisten voor OGC API Features implementaties.*
+  - *De brontekst bevat geen technische vereisten voor OGC API Features als INSPIRE download service.*
 
 ### `geo-inspire-0026` — reference.md:185 *(§ INSPIRE en OGC API Features)*
 
 > OGC API Features als INSPIRE download service vereist dat collecties mappen op INSPIRE feature types.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features download service
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Mapping van collecties op INSPIRE feature types wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van collecties die mappen op INSPIRE feature types.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over collecties of feature type mapping.*
+  - *De brontekst bevat geen informatie over collecties of feature type mapping voor OGC API Features.*
 
 ### `geo-inspire-0027` — reference.md:186 *(§ INSPIRE en OGC API Features)*
 
 > OGC API Features als INSPIRE download service vereist GeoJSON-output met INSPIRE-conforme attributen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features download service
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *GeoJSON-output met INSPIRE-conforme attributen wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van GeoJSON-output of INSPIRE-conforme attributen.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over GeoJSON-output vereisten.*
+  - *De brontekst bevat geen informatie over GeoJSON-output vereisten voor INSPIRE download services.*
 
 ### `geo-inspire-0028` — reference.md:187 *(§ INSPIRE en OGC API Features)*
 
 > OGC API Features als INSPIRE download service vereist CRS-ondersteuning voor EPSG:4258.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features download service
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *CRS-ondersteuning voor EPSG:4258 in OGC API Features context wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van CRS-ondersteuning voor OGC API Features download services.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over CRS-ondersteuning in OGC API Features context.*
+  - *De brontekst bevat geen informatie over CRS-ondersteuningsvereisten voor OGC API Features.*
 
 ### `geo-inspire-0029` — reference.md:188 *(§ INSPIRE en OGC API Features)*
 
 > OGC API Features als INSPIRE download service vereist filtering op INSPIRE-attributen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features download service
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
-  - *Filtering op INSPIRE-attributen wordt niet vermeld in de brontekst.*
+  - *Geen vermelding van filtering op INSPIRE-attributen via OGC API Features.*
 - **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
-  - *De brontekst bevat geen informatie over filtervereisten voor OGC API Features.*
+  - *De brontekst bevat geen informatie over filteringsvereisten op INSPIRE-attributen voor OGC API Features.*

--- a/skills/geo-inspire/audit.md
+++ b/skills/geo-inspire/audit.md
@@ -1,0 +1,344 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo-inspire — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 13 | 45% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 2 | 7% |
+| UNGROUNDED | 14 | 48% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 0 | 0% |
+
+*Geverifieerd met sonnet, 3 calls, $0.4661.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+
+### `geo-inspire-0002` — SKILL.md:28 *(§ Standaarden Overzicht)*
+
+> INSPIRE view services gebruiken WMS 1.3.0 of WMTS 1.0.0 als standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *De brontekst is een overzichtspagina van handreikingen. Technische details over WMS/WMTS versies worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst is de homepage van de INSPIRE Knowledge Base en bevat geen technische details over view services of WMS/WMTS standaarden.*
+
+### `geo-inspire-0003` — SKILL.md:29 *(§ Standaarden Overzicht)*
+
+> INSPIRE download services gebruiken WFS 2.0, Atom of OGC API Features als standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE download services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *De brontekst bevat geen informatie over WFS, Atom of OGC API Features als standaard voor download services.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over download services of WFS/Atom/OGC API Features.*
+
+### `geo-inspire-0004` — SKILL.md:30 *(§ Standaarden Overzicht)*
+
+> INSPIRE discovery services gebruiken CSW 2.0.2 als standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE discovery services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *CSW 2.0.2 wordt niet genoemd in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over discovery services of CSW.*
+
+### `geo-inspire-0005` — SKILL.md:31 *(§ Standaarden Overzicht)*
+
+> INSPIRE data-encoding gebruikt GML 3.2.1 voor geo-data uitwisseling.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE data-encoding
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *GML 3.2.1 wordt niet genoemd in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over data-encoding of GML.*
+
+### `geo-inspire-0006` — SKILL.md:32 *(§ Standaarden Overzicht)*
+
+> INSPIRE metadata gebruikt ISO 19115/19119 als standaard voor beschrijving van data en services.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *ISO 19115/19119 wordt niet genoemd in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over metadata standaarden zoals ISO 19115/19119.*
+
+### `geo-inspire-0007` — SKILL.md:43 *(§ INSPIRE Data Thema's)*
+
+> INSPIRE Annex I referentiedata is van toepassing sinds 2010.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Annex I
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen informatie over INSPIRE Annex I of toepassingsdatum 2010 in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over implementatiedata van Annex I.*
+
+### `geo-inspire-0008` — SKILL.md:57 *(§ INSPIRE Data Thema's)*
+
+> INSPIRE Annex II (fysisch milieu) en Annex III (milieu en maatschappij) zijn van toepassing sinds 2013.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Annex II en III
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Annex II en III en de datum 2013 worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over Annex II of III en hun toepassingsdatum.*
+
+### `geo-inspire-0014` — SKILL.md:150 *(§ Discovery Service (CSW))*
+
+> De Nederlandse INSPIRE discovery service is het Nationaal Georegister (NGR) op nationaalgeoregister.nl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE discovery services Nederland
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Het Nationaal Georegister of nationaalgeoregister.nl wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over de Nederlandse discovery service of nationaalgeoregister.nl.*
+
+### `geo-inspire-0016` — SKILL.md:214 *(§ Monitoring en Rapportage)*
+
+> Nederland rapporteert jaarlijks aan de EU over INSPIRE-implementatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE monitoring en rapportage Nederland
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Jaarlijkse rapportage aan de EU over INSPIRE-implementatie wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over Nederlandse rapportage aan de EU.*
+
+### `geo-inspire-0017` — SKILL.md:228 *(§ Veelvoorkomende Problemen)*
+
+> OGC API Features is erkend als INSPIRE Good Practice voor download services.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE download services / OGC API Features
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *OGC API Features als INSPIRE Good Practice wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over OGC API Features als Good Practice.*
+
+### `geo-inspire-0022` — reference.md:118 *(§ Monitoring en Rapportage)*
+
+> INSPIRE monitoring indicator MDi1 meet metadata beschikbaarheid met een doel van 100%.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE jaarlijkse monitoring indicatoren
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *INSPIRE monitoring indicator MDi1 wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over monitoring indicatoren zoals MDi1.*
+
+### `geo-inspire-0023` — reference.md:126 *(§ Monitoring en Rapportage)*
+
+> INSPIRE monitoring indicator NSi4 meet services beschikbaarheid (uptime) met een doel van ≥99%.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE jaarlijkse monitoring indicatoren
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *INSPIRE monitoring indicator NSi4 wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over monitoring indicator NSi4 of uptime-doelstellingen.*
+
+### `geo-inspire-0024` — reference.md:169 *(§ INSPIRE Validator Details)*
+
+> De INSPIRE Validator is gebaseerd op het ETF testing framework (etf-validator/etf-webapp op GitHub).
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE Validator / ETF
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *ETF testing framework en GitHub-repository worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst vermeldt de INSPIRE Validator maar geeft geen technische details over het ETF framework of de GitHub-repository.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
+
+### `geo-inspire-0001` — SKILL.md:22 *(§ INSPIRE Implementatie)*
+
+> De INSPIRE-richtlijn (2007/2/EG) verplicht Europese lidstaten om ruimtelijke data over 34 thema's interoperabel beschikbaar te stellen via view-, download- en discovery-services.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE-richtlijn 2007/2/EG
+
+- **PARTIALLY_SUPPORTED** (high) — [https://docs.geostandaarden.nl/eu/INSPIRE-handreiking](https://docs.geostandaarden.nl/eu/INSPIRE-handreiking)
+  > INSPIRE zorgt voor een hoge mate van interoperabiliteit door per thema een standaard dataspecificatie te beschrijven die door alle lidstaten geïmplementeerd moet worden. [...] Datasets en -services die onder één van de 34 INSPIRE-thema's vallen, moeten te vinden, raadplegen en downloaden zijn.
+  - *De bron bevestigt de 34 thema's, de interoperabiliteitsverplichting en de vereiste view-, download- en discovery-services. Echter: de discovery-service wordt in de claim niet expliciet als derde service genoemd (de claim noemt 'view-, download- en discovery-services'), terwijl de bron wel alle drie beschrijft. Verder is de claim technisch juist maar de bron stelt ook dat de INSPIRE-richtlijn zelf (2007/2/EG) dit oplegt via implementing rules en verordeningen — de directe koppeling aan het richtlijnnummer 2007/2/EG wordt in de bron alleen indirect bevestigd (via verwijzingen naar de verordening). De kern van de claim wordt ondersteund, maar de exacte formulering 'verplicht lidstaten' via de richtlijn zelf wordt niet letterlijk bevestigd; de bron spreekt van eisen uit implementing rules en verordeningen.*
+
+### `geo-inspire-0015` — SKILL.md:162 *(§ INSPIRE Validatie)*
+
+> De INSPIRE Validator is gebaseerd op het ETF testing framework en beschikbaar via inspire.ec.europa.eu/validator/.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE validatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  > Discontinuation of the INSPIRE Reference Validator After almost ten years since its introduction, the INSPIRE Reference Validator was discontinued on April 1st, 2026.
+  - *De brontekst bevestigt het bestaan van de INSPIRE Reference Validator en dat deze beschikbaar was via inspire.ec.europa.eu, maar vermeldt niets over het ETF testing framework of het specifieke URL-pad /validator/. Bovendien is de validator per 1 april 2026 stopgezet, wat de claim dat hij 'beschikbaar via' is tegenspreekt in de huidige toestand — maar de claim zelf is historisch juist.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *De INSPIRE Validator en het ETF testing framework worden niet vermeld in de brontekst.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (14)
+
+### `geo-inspire-0009` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten voldoen aan WMS 1.3.0 of WMTS 1.0.0.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geen technische vereisten voor view services in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen technische vereisten voor view services.*
+
+### `geo-inspire-0010` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten INSPIRE Extended Capabilities bevatten in de GetCapabilities response.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *INSPIRE Extended Capabilities wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over INSPIRE Extended Capabilities.*
+
+### `geo-inspire-0011` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten ondersteuning bieden voor EPSG:4258 (ETRS89) en optioneel EPSG:3035 (ETRS89-LAEA).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *EPSG:4258 en EPSG:3035 worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over CRS-vereisten voor view services.*
+
+### `geo-inspire-0012` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten meertalige ondersteuning bieden, minimaal Engels en Nederlands.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Meertalige ondersteuning voor view services wordt niet besproken in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over meertalige vereisten voor view services.*
+
+### `geo-inspire-0013` — SKILL.md:96 *(§ View Service (WMS/WMTS))*
+
+> INSPIRE view services moeten specifieke laagnamen conform INSPIRE data specificaties hanteren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE view services
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Laagnamen conform INSPIRE data specificaties worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over laagnamen in view services.*
+
+### `geo-inspire-0018` — reference.md:43 *(§ Transformatieregels)*
+
+> NEN3610ID wordt bij INSPIRE-transformatie vertaald naar INSPIRE `inspireId` (namespace + localId + versionId).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels identificatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *NEN3610ID en INSPIRE inspireId worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over NEN3610ID of INSPIRE inspireId transformaties.*
+
+### `geo-inspire-0019` — reference.md:44 *(§ Transformatieregels)*
+
+> Bij INSPIRE-transformatie moet geometrie getransformeerd worden van EPSG:28992 (RD New) naar EPSG:4258 (ETRS89).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels geometrie/CRS
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Geometrietransformatie van EPSG:28992 naar EPSG:4258 wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over geometrietransformaties of CRS-conversies.*
+
+### `geo-inspire-0020` — reference.md:45 *(§ Transformatieregels)*
+
+> Bij INSPIRE-transformatie worden NL-waarden gemapped naar INSPIRE codelijsten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels codelijsten
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Mapping van NL-waarden naar INSPIRE codelijsten wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over codelijst-mapping bij INSPIRE-transformatie.*
+
+### `geo-inspire-0021` — reference.md:46 *(§ Transformatieregels)*
+
+> Bij INSPIRE-transformatie worden beginGeldigheid/eindGeldigheid vertaald naar het INSPIRE temporeel model.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE transformatieregels temporele attributen
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *BeginGeldigheid/eindGeldigheid en INSPIRE temporeel model worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over temporele attributen of beginGeldigheid/eindGeldigheid.*
+
+### `geo-inspire-0025` — reference.md:184 *(§ INSPIRE en OGC API Features)*
+
+> OGC API Features als INSPIRE download service vereist een landingspagina met INSPIRE metadata-link.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Vereisten voor OGC API Features landingspagina worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen technische vereisten voor OGC API Features implementaties.*
+
+### `geo-inspire-0026` — reference.md:185 *(§ INSPIRE en OGC API Features)*
+
+> OGC API Features als INSPIRE download service vereist dat collecties mappen op INSPIRE feature types.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Mapping van collecties op INSPIRE feature types wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over collecties of feature type mapping.*
+
+### `geo-inspire-0027` — reference.md:186 *(§ INSPIRE en OGC API Features)*
+
+> OGC API Features als INSPIRE download service vereist GeoJSON-output met INSPIRE-conforme attributen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *GeoJSON-output met INSPIRE-conforme attributen wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over GeoJSON-output vereisten.*
+
+### `geo-inspire-0028` — reference.md:187 *(§ INSPIRE en OGC API Features)*
+
+> OGC API Features als INSPIRE download service vereist CRS-ondersteuning voor EPSG:4258.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *CRS-ondersteuning voor EPSG:4258 in OGC API Features context wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over CRS-ondersteuning in OGC API Features context.*
+
+### `geo-inspire-0029` — reference.md:188 *(§ INSPIRE en OGC API Features)*
+
+> OGC API Features als INSPIRE download service vereist filtering op INSPIRE-attributen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE OGC API Features implementatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/eu/](https://docs.geostandaarden.nl/eu/)
+  - *Filtering op INSPIRE-attributen wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://inspire.ec.europa.eu/](https://inspire.ec.europa.eu/)
+  - *De brontekst bevat geen informatie over filtervereisten voor OGC API Features.*

--- a/skills/geo-meta/audit.md
+++ b/skills/geo-meta/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo-meta — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,60 +7,71 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 19 | 34% |
+| UNSUPPORTED_ASSERTION | 22 | 40% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 1 | 2% |
-| UNGROUNDED | 34 | 61% |
+| PARTIALLY_GROUNDED | 0 | 0% |
+| UNGROUNDED | 29 | 53% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 2 | 4% |
+| GROUNDED | 4 | 7% |
 
-*Geverifieerd met sonnet, 5 calls, $0.5966.*
+*Geverifieerd met sonnet, 6 calls, $0.6475.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (19)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (22)
 
 ### `geo-meta-0002` — SKILL.md:22 *(§ Metadata voor Geodata)*
 
 > Het Nationaal Georegister (NGR) is het centrale portaal voor het zoeken en publiceren van metadata over Nederlandse geodatasets en -services.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — Nationaal Georegister
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nationaal Georegister (NGR)
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
-  - *De brontekst bevat geen vermelding van het Nationaal Georegister (NGR) als centraal portaal.*
+  - *De bron beschrijft het Nederlandse metadata profiel op ISO 19115, maar noemt het Nationaal Georegister (NGR) nergens.*
+
+### `geo-meta-0010` — SKILL.md:56 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element Ruimtelijk referentiesysteem (`referenceSystemInfo`) bevat het CRS (bijv. EPSG:28992).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen inhoudelijke specificaties over referenceSystemInfo.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over referenceSystemInfo of CRS.*
 
 ### `geo-meta-0014` — SKILL.md:149 *(§ CSW (Catalogue Service for the Web))*
 
-> CSW 2.0.2 is het OGC-protocol voor het zoeken en harvesten van metadata.
+> CSW is het OGC-protocol voor het zoeken en harvesten van metadata. Het NGR biedt een CSW-endpoint.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CSW — Catalogue Service for the Web
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CSW 2.0.2, NGR
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over CSW of NGR.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over CSW 2.0.2.*
+  - *De brontekst is een directory-index en bevat geen informatie over CSW of NGR.*
 
 ### `geo-meta-0015` — SKILL.md:153 *(§ CSW (Catalogue Service for the Web))*
 
-> Het NGR biedt een CSW-endpoint op https://www.nationaalgeoregister.nl/geonetwork/srv/dut/csw.
+> Het NGR CSW-endpoint is bereikbaar op https://www.nationaalgeoregister.nl/geonetwork/srv/dut/csw met versie 2.0.2.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — CSW-endpoint
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR CSW endpoint
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen URL-informatie over NGR CSW-endpoint.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over het NGR CSW-endpoint.*
+  - *De brontekst is een directory-index en bevat geen informatie over het NGR CSW-endpoint.*
 
 ### `geo-meta-0017` — SKILL.md:198 *(§ DCAT voor Geodata)*
 
-> GeoDCAT-AP biedt een mapping van ISO 19115 naar DCAT.
+> GeoDCAT-AP biedt een mapping van ISO 19115 naar DCAT (RDF) voor koppeling met data.overheid.nl en het Europese data-portaal.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP, ISO 19115, DCAT
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over GeoDCAT-AP of ISO 19115 naar DCAT mapping.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP.*
+  - *De brontekst is een directory-index en bevat geen informatie over GeoDCAT-AP of ISO 19115 naar DCAT mapping.*
 
 ### `geo-meta-0018` — SKILL.md:198 *(§ DCAT voor Geodata)*
 
@@ -69,556 +80,526 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over DCAT-AP-NL.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over DCAT-AP-NL.*
+  - *De brontekst is een directory-index en bevat geen informatie over DCAT-AP-NL.*
 
 ### `geo-meta-0019` — SKILL.md:216 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Titel' mapt naar DCAT property `dct:title`.
+> ISO 19115 element Titel mapt naar DCAT property `dct:title`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0020` — SKILL.md:217 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Samenvatting' mapt naar DCAT property `dct:description`.
+> ISO 19115 element Samenvatting mapt naar DCAT property `dct:description`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0021` — SKILL.md:218 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Verantwoordelijke organisatie' mapt naar DCAT property `dct:publisher`.
+> ISO 19115 element Verantwoordelijke organisatie mapt naar DCAT property `dct:publisher`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0022` — SKILL.md:219 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Trefwoorden' mapt naar DCAT property `dcat:keyword`.
+> ISO 19115 element Trefwoorden mapt naar DCAT property `dcat:keyword`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0023` — SKILL.md:220 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Datum (publicatie)' mapt naar DCAT property `dct:issued`.
+> ISO 19115 element Datum (publicatie) mapt naar DCAT property `dct:issued`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0024` — SKILL.md:221 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Distributie (URL)' mapt naar DCAT property `dcat:distribution`.
+> ISO 19115 element Distributie (URL) mapt naar DCAT property `dcat:distribution`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0025` — SKILL.md:222 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Ruimtelijke dekking (bbox)' mapt naar DCAT property `dct:spatial`.
+> ISO 19115 element Ruimtelijke dekking (bbox) mapt naar DCAT property `dct:spatial`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
 ### `geo-meta-0026` — SKILL.md:223 *(§ Verhouding ISO 19115 en DCAT)*
 
-> ISO 19115 element 'Temporele dekking' mapt naar DCAT property `dct:temporal`.
+> ISO 19115 element Temporele dekking mapt naar DCAT property `dct:temporal`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
-
-### `geo-meta-0051` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
-
-> DCAT-AP profielen worden gedefinieerd in SHACL; DCAT-AP-NL bouwt voort op de SHACL-shapes van DCAT-AP met aanvullende Nederlandse regels.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — SHACL validatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ISO 19115 naar DCAT mapping
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen mapping-informatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over SHACL-validatie voor DCAT-AP-NL.*
+  - *De brontekst is een directory-index en bevat geen mapping-informatie.*
 
-### `geo-meta-0052` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
+### `geo-meta-0046` — reference.md:100 *(§ ISO XML metadata)*
 
-> Er zijn meerdere validatieniveaus voor DCAT-AP-NL: alleen verplichte eigenschappen, aanbevolen eigenschappen, of inclusief HVD-eisen (High-Value Datasets).
+> De Geonovum validator voor ISO XML metadata is bereikbaar op https://validatie.geostandaarden.nl/etf-webapp/v2/TestRuns.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — SHACL validatie niveaus
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Validatietools, Nederlands profiel ISO 19115
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over validatietools of URLs daarvoor.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over validatieniveaus voor DCAT-AP-NL.*
+  - *De brontekst is een directory-index en bevat geen informatie over validatietools of validatie.geostandaarden.nl.*
 
-### `geo-meta-0053` — reference.md:183 *(§ DCAT en GeoDCAT-AP)*
+### `geo-meta-0047` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
+
+> DCAT-AP profielen worden gedefinieerd in SHACL. DCAT-AP-NL bouwt voort op de SHACL-shapes van DCAT-AP met aanvullende Nederlandse regels.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL, SHACL-validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over SHACL of DCAT-AP profielen.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over SHACL of DCAT-AP profielen.*
+
+### `geo-meta-0048` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
+
+> Er zijn meerdere DCAT-AP validatieniveaus: alleen verplichte eigenschappen, aanbevolen eigenschappen, of inclusief HVD-eisen (High-Value Datasets).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL, SHACL-validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over DCAT-AP validatieniveaus.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over DCAT-AP validatieniveaus.*
+
+### `geo-meta-0049` — reference.md:113 *(§ DCAT metadata (SHACL-validatie))*
+
+> De DCAT-AP online validator (Europa) is beschikbaar op https://www.itb.ec.europa.eu/shacl/semic-shacl/upload en ondersteunt verschillende versies en niveaus van DCAT-AP.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP validatietools
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over DCAT-AP validatietools of URLs.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over DCAT-AP validatietools.*
+
+### `geo-meta-0050` — reference.md:134 *(§ DCAT metadata (SHACL-validatie))*
+
+> DCAT metadata maakt vaak gebruik van URI's naar externe registraties, zoals TOOI URI's voor overheidsorganisaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over DCAT metadata of TOOI URI's.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over DCAT metadata of TOOI URI's.*
+
+### `geo-meta-0051` — reference.md:164 *(§ Optie C: GeoNetwork REST API)*
+
+> Metadata uploaden via GeoNetwork REST API kan via PUT naar https://www.nationaalgeoregister.nl/geonetwork/srv/api/records met X-XSRF-TOKEN header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR publicatieworkflow, GeoNetwork REST API
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over GeoNetwork REST API of uploadmethoden.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over GeoNetwork REST API of uploaden van metadata.*
+
+### `geo-meta-0052` — reference.md:183 *(§ DCAT en GeoDCAT-AP)*
 
 > GeoDCAT-AP is een Europees profiel dat ISO 19115 metadata mapt naar DCAT (RDF), relevant voor koppeling met data.overheid.nl en het Europese data-portaal.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over GeoDCAT-AP.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP.*
+  - *De brontekst is een directory-index en bevat geen informatie over GeoDCAT-AP.*
 
-### `geo-meta-0054` — SKILL.md:85 *(§ Voorbeeld Metadata XML (NL profiel))*
+### `geo-meta-0055` — SKILL.md:85 *(§ Voorbeeld Metadata XML (NL profiel))*
 
-> Het NL profiel op ISO 19115 heeft versienummer 2.1.0 (`metadataStandardVersion`).
+> Het metadataStandardVersion element in het XML-voorbeeld heeft de waarde 'Nederlands metadata profiel op ISO 19115 voor geografie 2.1.0'.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115 — versie
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen XML-voorbeelden of waarden van metadataStandardVersion.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over versienummer van het NL profiel op ISO 19115.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over metadataStandardVersion waarden.*
 
-### `geo-meta-0055` — reference.md:163 *(§ Optie C: GeoNetwork REST API)*
-
-> Metadata uploaden via de GeoNetwork REST API kan via PUT op https://www.nationaalgeoregister.nl/geonetwork/srv/api/records met een X-XSRF-TOKEN header.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — GeoNetwork REST API publicatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is een directory-index van docs.geostandaarden.nl/md met alleen bestandsnamen en datums. Er staat niets over GeoNetwork REST API, PUT-requests, of X-XSRF-TOKEN headers.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De aangeleverde brontekst is een directory-listing van docs.geostandaarden.nl/mim en bevat geen informatie over de GeoNetwork REST API, PUT-endpoints of X-XSRF-TOKEN headers.*
-
-### `geo-meta-0056` — reference.md:134 *(§ DCAT metadata (SHACL-validatie))*
-
-> DCAT metadata maakt gebruik van URI's naar externe registraties, zoals TOOI URI's voor overheidsorganisaties; bij validatie zijn externe URI-verwijzingen niet altijd te controleren zonder ze te volgen.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — validatie beperkingen
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is een directory-index van docs.geostandaarden.nl/md met alleen bestandsnamen en datums. Er staat niets over DCAT-AP-NL, URI-validatie, of TOOI URI's.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De aangeleverde brontekst is een directory-listing van docs.geostandaarden.nl/mim en bevat geen informatie over DCAT-AP-NL, URI-validatie of TOOI URI's voor overheidsorganisaties.*
-
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
-
-### `geo-meta-0001` — SKILL.md:20 *(§ Metadata voor Geodata)*
-
-> Metadata (ISO 19115/19119) is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115/19119 — Forum Standaardisatie
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
-  > Beide profielen staan op de Pas-toe-of-leg-uit-lijst van het College Standaardisatie.
-  - *De bron bevestigt dat beide profielen (ISO 19115 en ISO 19119) op de pas-toe-of-leg-uit-lijst staan, maar noemt het 'College Standaardisatie', niet het 'Forum Standaardisatie'. Dit kan dezelfde instantie zijn onder een andere naam, maar de bron gebruikt expliciet 'College Standaardisatie'.*
-
-## UNGROUNDED — geen bron ondersteunt de claim (34)
+## UNGROUNDED — geen bron ondersteunt de claim (29)
 
 ### `geo-meta-0004` — SKILL.md:28 *(§ Standaarden Overzicht)*
 
 > ISO 19115:2003/19115-1:2014 heeft Forum Standaardisatie status 'Verplicht' voor beschrijving van datasets.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115 — Forum Standaardisatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115, Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is een directory-index van docs.geostandaarden.nl/md/ met alleen bestandsnamen en datums. Geen inhoud over Forum Standaardisatie-statussen.*
+  - *De brontekst is een directory-index van /md op docs.geostandaarden.nl. Geen inhoudelijke informatie over Forum Standaardisatie status.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/ op docs.geostandaarden.nl. Bevat geen informatie over Forum Standaardisatie-status van ISO 19115.*
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/mim en bevat geen informatie over Forum Standaardisatie status van ISO 19115.*
 
 ### `geo-meta-0005` — SKILL.md:29 *(§ Standaarden Overzicht)*
 
 > ISO 19119:2005 heeft Forum Standaardisatie status 'Verplicht' voor beschrijving van services.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — Forum Standaardisatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119, Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst bevat alleen een directory-listing. Geen informatie over Forum Standaardisatie-status van ISO 19119.*
+  - *Directory-index bevat geen informatie over Forum Standaardisatie status van ISO 19119.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over Forum Standaardisatie-status van ISO 19119.*
+  - *De brontekst is een directory-index en bevat geen informatie over Forum Standaardisatie status van ISO 19119.*
 
 ### `geo-meta-0006` — SKILL.md:30 *(§ Standaarden Overzicht)*
 
-> Het NL profiel op ISO 19115 heeft Forum Standaardisatie status 'Verplicht'.
+> Het NL profiel ISO 19115 heeft Forum Standaardisatie status 'Verplicht' als Nederlandse invulling van ISO 19115.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — Forum Standaardisatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst bevat alleen een directory-listing. Geen informatie over Forum Standaardisatie-status van het NL profiel.*
+  - *Directory-index bevat geen informatie over Forum Standaardisatie status van het NL profiel ISO 19115.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over Forum Standaardisatie-status van het NL profiel op ISO 19115.*
+  - *De brontekst is een directory-index en bevat geen informatie over Forum Standaardisatie status van het NL profiel ISO 19115.*
 
 ### `geo-meta-0007` — SKILL.md:32 *(§ Standaarden Overzicht)*
 
-> DCAT-AP-NL heeft Forum Standaardisatie status 'Aanbevolen' voor geodata-metadata.
+> DCAT-AP-NL heeft Forum Standaardisatie status 'Aanbevolen' voor geo-extensie via GeoDCAT-AP.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DCAT-AP-NL — Forum Standaardisatie
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DCAT-AP-NL, Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst bevat alleen een directory-listing. Geen informatie over DCAT-AP-NL of Forum Standaardisatie.*
+  - *Directory-index bevat geen informatie over DCAT-AP-NL of Forum Standaardisatie status.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over DCAT-AP-NL.*
+  - *De brontekst is een directory-index en bevat geen informatie over DCAT-AP-NL of Forum Standaardisatie status.*
 
 ### `geo-meta-0009` — SKILL.md:54 *(§ Verplichte elementen (dataset))*
 
-> Het verplichte element 'Trefwoorden' vereist minstens 1 trefwoord (`identificationInfo/descriptiveKeywords`).
+> Het verplichte element Trefwoorden (`identificationInfo/descriptiveKeywords`) vereist minstens 1 trefwoord.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over verplichte elementen in het NL profiel op ISO 19115.*
-
-### `geo-meta-0010` — SKILL.md:56 *(§ Verplichte elementen (dataset))*
-
-> Het verplichte element 'Ruimtelijk referentiesysteem' bevat het CRS, bijvoorbeeld EPSG:28992 (`referenceSystemInfo`).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over verplichte elementen.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over referenceSystemInfo of CRS-eisen.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over het NL profiel ISO 19115.*
 
 ### `geo-meta-0011` — SKILL.md:58 *(§ Verplichte elementen (dataset))*
 
-> Het verplichte element 'Taal' geeft de taal van de dataset aan als 'dut' of 'nld' (`identificationInfo/language`).
+> Het verplichte element Taal (`identificationInfo/language`) bevat de taal van de dataset als 'dut' of 'nld'.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over taal-elementen.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over taal-elementen in het NL profiel.*
+  - *De brontekst is een directory-index en bevat geen informatie over taal-elementen in het NL profiel.*
 
 ### `geo-meta-0012` — SKILL.md:63 *(§ Verplichte elementen (dataset))*
 
-> Het verplichte element 'Metadata-standaard' heeft de waarde 'ISO 19115' (`metadataStandardName`).
+> Het verplichte element Metadata-standaard (`metadataStandardName`) heeft de waarde 'ISO 19115'.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over metadataStandardName.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadataStandardName.*
+  - *De brontekst is een directory-index en bevat geen informatie over metadataStandardName.*
 
 ### `geo-meta-0013` — SKILL.md:65 *(§ Verplichte elementen (dataset))*
 
-> Het verplichte element 'Metadata-taal' heeft de waarde 'dut' of 'nld' (`language`).
+> Het verplichte element Metadata-taal (`language`) heeft de waarde 'dut' of 'nld'.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over metadata-taal.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadata-taal.*
+  - *De brontekst is een directory-index en bevat geen informatie over metadata-taal elementen.*
 
 ### `geo-meta-0016` — SKILL.md:233 *(§ Veelvoorkomende Problemen)*
 
-> In CSW CQL-syntax wordt het procent-teken (%) gebruikt als wildcard bij `AnyText like '%term%'`.
+> In CSW CQL-queries wordt het procent-teken gebruikt als wildcard in AnyText like '%term%'.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** CSW — CQL query syntax
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over CSW CQL-syntax.*
-
-### `geo-meta-0027` — SKILL.md:232 *(§ Veelvoorkomende Problemen)*
-
-> Om metadata vindbaar te maken voor INSPIRE moeten INSPIRE-trefwoorden (GEMET thesaurus) worden toegevoegd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE — metadata trefwoorden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** CSW 2.0.2 CQL_TEXT queries
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over CSW CQL-queries.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over INSPIRE-trefwoorden of GEMET thesaurus.*
+  - *De brontekst is een directory-index en bevat geen informatie over CSW CQL-queries of wildcards.*
+
+### `geo-meta-0027` — SKILL.md:242 *(§ Publiceren in het NGR)*
+
+> Metadata valideren tegen het NL profiel is vereist voordat gepubliceerd wordt in het NGR.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NGR publicatieworkflow, Nederlands profiel ISO 19115
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *Directory-index bevat geen informatie over NGR publicatieworkflow of validatievereisten.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directory-index en bevat geen informatie over NGR publicatieworkflow of validatie.*
 
 ### `geo-meta-0028` — reference.md:11 *(§ Dataset Metadata)*
 
-> Het element `fileIdentifier` is verplicht, niet herhaalbaar, en bevat een unieke UUID van het metadata-record.
+> Het NL profiel vereist voor dataset metadata het element `fileIdentifier` als unieke UUID van het metadata-record.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over fileIdentifier.*
-
-### `geo-meta-0029` — reference.md:12 *(§ Dataset Metadata)*
-
-> Het element `language` (metadata-taal) is verplicht en niet herhaalbaar; waarde is 'dut' of 'nld'.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over fileIdentifier.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadata-taal element.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over fileIdentifier.*
 
-### `geo-meta-0030` — reference.md:13 *(§ Dataset Metadata)*
+### `geo-meta-0029` — reference.md:14 *(§ Dataset Metadata)*
 
-> Het element `characterSet` is conditioneel en niet herhaalbaar; de standaardwaarde is 'utf8'.
+> Het NL profiel vereist voor dataset metadata het element `hierarchyLevel` met waarde dataset, series, of service.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over hierarchyLevel.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over characterSet.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over hierarchyLevel.*
 
-### `geo-meta-0031` — reference.md:14 *(§ Dataset Metadata)*
+### `geo-meta-0030` — reference.md:16 *(§ Dataset Metadata)*
 
-> Het element `hierarchyLevel` is verplicht en niet herhaalbaar; mogelijke waarden zijn 'dataset', 'series' of 'service'.
+> Het NL profiel vereist voor dataset metadata het element `dateStamp` in formaat YYYY-MM-DD.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over dateStamp.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over hierarchyLevel.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over dateStamp.*
 
-### `geo-meta-0032` — reference.md:15 *(§ Dataset Metadata)*
+### `geo-meta-0031` — reference.md:17 *(§ Dataset Metadata)*
 
-> Het element `contact` is verplicht en herhaalbaar; het bevat contactgegevens van de metadata-beheerder.
+> Het NL profiel vereist voor dataset metadata het element `metadataStandardName` met waarde 'ISO 19115'.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over metadataStandardName.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over contact-element.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over metadataStandardName.*
 
-### `geo-meta-0033` — reference.md:16 *(§ Dataset Metadata)*
+### `geo-meta-0032` — reference.md:18 *(§ Dataset Metadata)*
 
-> Het element `dateStamp` is verplicht, niet herhaalbaar, en heeft het formaat YYYY-MM-DD.
+> Het NL profiel vereist voor dataset metadata het element `metadataStandardVersion` met de versie van het NL profiel.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over metadataStandardVersion.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over dateStamp.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over metadataStandardVersion.*
 
-### `geo-meta-0034` — reference.md:17 *(§ Dataset Metadata)*
+### `geo-meta-0033` — reference.md:19 *(§ Dataset Metadata)*
 
-> Het element `metadataStandardName` is verplicht, niet herhaalbaar, en heeft de waarde 'ISO 19115'.
+> Het NL profiel vereist voor dataset metadata het element `referenceSystemInfo` (herhaalbaar) met het CRS (bijv. EPSG:28992).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over referenceSystemInfo.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadataStandardName.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over referenceSystemInfo.*
 
-### `geo-meta-0035` — reference.md:19 *(§ Dataset Metadata)*
+### `geo-meta-0034` — reference.md:21 *(§ Dataset Metadata)*
 
-> Het element `referenceSystemInfo` is verplicht en herhaalbaar; het bevat het CRS, bijvoorbeeld EPSG:28992.
+> Het NL profiel vereist voor dataset metadata het element `distributionInfo` met distributie-informatie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, dataset metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over distributionInfo.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over referenceSystemInfo.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over distributionInfo.*
 
-### `geo-meta-0036` — reference.md:21 *(§ Dataset Metadata)*
+### `geo-meta-0035` — reference.md:35 *(§ Identificatie-elementen (MD_DataIdentification))*
 
-> Het element `distributionInfo` is verplicht en niet herhaalbaar in het NL profiel op ISO 19115.
+> Het NL profiel vereist voor identificatie-elementen `descriptiveKeywords` met minstens 1 trefwoord.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, MD_DataIdentification
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over descriptiveKeywords.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over distributionInfo.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over descriptiveKeywords.*
 
-### `geo-meta-0037` — reference.md:35 *(§ Identificatie-elementen (MD_DataIdentification))*
+### `geo-meta-0036` — reference.md:36 *(§ Identificatie-elementen (MD_DataIdentification))*
 
-> Het identificatie-element `descriptiveKeywords` (trefwoorden) is verplicht en vereist minstens 1 trefwoord.
+> Het NL profiel vereist voor identificatie-elementen `resourceConstraints` met gebruiksbeperkingen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, MD_DataIdentification
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over resourceConstraints.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over descriptiveKeywords.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over resourceConstraints.*
 
-### `geo-meta-0038` — reference.md:36 *(§ Identificatie-elementen (MD_DataIdentification))*
+### `geo-meta-0037` — reference.md:41 *(§ Identificatie-elementen (MD_DataIdentification))*
 
-> Het identificatie-element `resourceConstraints` (gebruiksbeperkingen) is verplicht.
+> Het NL profiel vereist voor identificatie-elementen `topicCategory` met minstens 1 ISO-categorie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, MD_DataIdentification
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke specificaties over topicCategory.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over resourceConstraints.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke informatie over topicCategory.*
 
-### `geo-meta-0039` — reference.md:38 *(§ Identificatie-elementen (MD_DataIdentification))*
+### `geo-meta-0038` — reference.md:66 *(§ Service Metadata (ISO 19119))*
 
-> Het identificatie-element `spatialResolution` (schaal of grondresolutie) is verplicht.
+> Voor services (WMS, WFS, CSW) is het element `serviceType` verplicht met waarden zoals OGC:WMS, OGC:WFS, OGC:CSW.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119, service metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over service metadata elementen.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over spatialResolution.*
+  - *De brontekst is een directory-index en bevat geen informatie over ISO 19119 service metadata elementen.*
 
-### `geo-meta-0040` — reference.md:41 *(§ Identificatie-elementen (MD_DataIdentification))*
+### `geo-meta-0039` — reference.md:67 *(§ Service Metadata (ISO 19119))*
 
-> Het identificatie-element `topicCategory` (ISO-categorie) is verplicht en vereist minstens 1 categorie.
+> Voor services is het element `serviceTypeVersion` verplicht met de versie van het service-protocol.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119, service metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over serviceTypeVersion.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over topicCategory.*
+  - *De brontekst is een directory-index en bevat geen informatie over serviceTypeVersion.*
 
-### `geo-meta-0041` — reference.md:42 *(§ Identificatie-elementen (MD_DataIdentification))*
+### `geo-meta-0040` — reference.md:68 *(§ Service Metadata (ISO 19119))*
 
-> Het identificatie-element `extent` (ruimtelijke en temporele dekking) is verplicht.
+> Voor services is het element `couplingType` verplicht met waarde tight, mixed of loose.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119, service metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over couplingType.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over extent-element.*
+  - *De brontekst is een directory-index en bevat geen informatie over couplingType.*
 
-### `geo-meta-0042` — reference.md:66 *(§ Service Metadata (ISO 19119))*
+### `geo-meta-0041` — reference.md:69 *(§ Service Metadata (ISO 19119))*
 
-> Voor service metadata (ISO 19119) is het element `serviceType` verplicht; waarden zijn OGC:WMS, OGC:WFS, OGC:CSW, etc.
+> Voor services is het element `containsOperations` verplicht met de operaties (GetCapabilities, GetMap, etc.).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119, service metadata
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over containsOperations.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over serviceType voor ISO 19119.*
+  - *De brontekst is een directory-index en bevat geen informatie over containsOperations.*
 
-### `geo-meta-0043` — reference.md:67 *(§ Service Metadata (ISO 19119))*
+### `geo-meta-0042` — reference.md:77 *(§ Structurele validatie)*
 
-> Voor service metadata is het element `serviceTypeVersion` (versie van het service-protocol) verplicht.
+> Het metadata-record moet voldoen aan het ISO 19115 XML-schema (gmd namespace) met correcte namespace-declaraties.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115 structurele validatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over XML-schema validatie of namespace-declaraties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over serviceTypeVersion.*
+  - *De brontekst is een directory-index en bevat geen informatie over XML-schema validatie of gmd namespace.*
 
-### `geo-meta-0044` — reference.md:68 *(§ Service Metadata (ISO 19119))*
+### `geo-meta-0043` — reference.md:87 *(§ Inhoudelijke validatie (NL profiel))*
 
-> Voor service metadata is het element `couplingType` verplicht; mogelijke waarden zijn 'tight', 'mixed' of 'loose'.
+> Inhoudelijke validatie vereist dat de samenvatting minimaal 25 tekens bevat.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, inhoudelijke validatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke validatieregels.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over couplingType.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke validatieregels.*
 
-### `geo-meta-0045` — reference.md:69 *(§ Service Metadata (ISO 19119))*
+### `geo-meta-0044` — reference.md:89 *(§ Inhoudelijke validatie (NL profiel))*
 
-> Voor service metadata is het element `containsOperations` (operaties zoals GetCapabilities, GetMap) verplicht.
+> Inhoudelijke validatie vereist dat contactgegevens een organisatienaam en e-mailadres bevatten.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, inhoudelijke validatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen inhoudelijke validatieregels over contactgegevens.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over containsOperations.*
+  - *De brontekst is een directory-index en bevat geen inhoudelijke validatieregels over contactgegevens.*
 
-### `geo-meta-0046` — reference.md:70 *(§ Service Metadata (ISO 19119))*
+### `geo-meta-0045` — reference.md:90 *(§ Inhoudelijke validatie (NL profiel))*
 
-> Voor service metadata is het element `operatesOn` (link naar dataset-metadata) conditioneel.
+> Inhoudelijke validatie vereist dat de bounding box valt binnen Nederland (lat: 50.75-53.47, lon: 3.37-7.21) of breder is.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** ISO 19119 — service metadata
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115, inhoudelijke validatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen validatieregels over bounding box coördinaten.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over operatesOn.*
+  - *De brontekst is een directory-index en bevat geen informatie over bounding box validatie.*
 
-### `geo-meta-0047` — reference.md:77 *(§ Structurele validatie)*
+### `geo-meta-0054` — SKILL.md:232 *(§ Veelvoorkomende Problemen)*
 
-> Metadata moet voldoen aan het ISO 19115 XML-schema (gmd namespace) voor structurele validatie.
+> Voor INSPIRE-metadata moeten INSPIRE-thematrefwoorden worden toegevoegd uit de GEMET thesaurus.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115 — structurele validatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE metadata, NGR
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+  - *Directory-index bevat geen informatie over INSPIRE-metadata of GEMET thesaurus.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over ISO 19115 XML-schema validatie.*
+  - *De brontekst is een directory-index en bevat geen informatie over INSPIRE-metadata of GEMET thesaurus.*
 
-### `geo-meta-0048` — reference.md:88 *(§ Inhoudelijke validatie (NL profiel))*
-
-> Bij inhoudelijke validatie (NL profiel) moet de samenvatting minimaal 25 tekens bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over inhoudelijke validatieregels.*
-
-### `geo-meta-0049` — reference.md:89 *(§ Inhoudelijke validatie (NL profiel))*
-
-> Bij inhoudelijke validatie moeten contactgegevens een organisatienaam en e-mailadres bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over contactgegevens-eisen.*
-
-### `geo-meta-0050` — reference.md:90 *(§ Inhoudelijke validatie (NL profiel))*
-
-> De bounding box moet binnen of gelijk aan Nederland vallen (lat: 50.75-53.47, lon: 3.37-7.21) of breder zijn.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
-  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over bounding box-eisen.*
-
-## GROUNDED — minstens één bron ondersteunt de claim (2)
+## GROUNDED — minstens één bron ondersteunt de claim (4)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-meta-0001` — SKILL.md:20 *(§ Metadata voor Geodata)*
+
+> Metadata (ISO 19115/19119) is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115/19119 metadata, Forum Standaardisatie
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Nederlands metadataprofiel op ISO 19115 voor geografie, versie 2.1.0 (specifiek toepassingsgebied : metadatering van geografische datasets en dataset series) Nederlands metadata profiel op ISO 19119 voor services, versie 2.1.0 (specifiek toepassingsgebied : metadatering van geografische informatie services)
+  - *De bron bevestigt expliciet dat beide metadataprofielen (ISO 19115 en ISO 19119) onderdeel zijn van de Geo-standaarden op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
+  > Beide profielen staan op de Pas-toe-of-leg-uit-lijst van het College Standaardisatie.
+  - *De bron bevestigt de Pas-toe-of-leg-uit-status, maar noemt 'College Standaardisatie' in plaats van 'Forum Standaardisatie'. Dit zijn verschillende organen. Verder vermeldt de bron alleen het dataset-profiel (ISO 19115) en het services-profiel (ISO 19119) als beide op de lijst staand, wat de claim ondersteunt, maar de naamsverschil levert een lichte discrepantie op.*
+- **NOT_FOUND** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst bevat alleen de navigatiestructuur en algemene paginaindeling van de Forum Standaardisatie 'Lijst open standaarden'-pagina. Er staat geen concrete lijst van standaarden met namen zoals ISO 19115 of ISO 19119. De claim kan hiermee niet worden bevestigd of weerlegd.*
 
 ### `geo-meta-0003` — SKILL.md:22 *(§ Metadata voor Geodata)*
 
@@ -627,7 +608,7 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115/19119
 
 - **SUPPORTED** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
-  > Geonovum ontwikkelt en beheert de Nederlandse metadata profielen. Deze profielen zijn een verbijzondering van de internationale metadatastandaarden van ISO en zijn bedoeld om de interoperabiliteit binnen Nederland te bevorderen.
+  > Geonovum ontwikkelt en beheert de Nederlandse metadata profielen. Deze profielen zijn een verbijzondering van de internationale metadatastandaarden van ISO en zijn bedoeld om de interoperabiliteit binnen Nederland te bevorderen. De volgende metadata profielen worden ondersteund en gebruikt: datasets: Nederlands metadata profiel op ISO 19115 voor geografie versie 2.0.0 services: Nederlands metad...
 
 ### `geo-meta-0008` — SKILL.md:44 *(§ Nederlands Profiel ISO 19115)*
 
@@ -636,7 +617,16 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115
 
 - **SUPPORTED** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
-  > In de volgende tabel staan de verplichte of bij conditie verplichte elementen. [...] Naast de verplichte kernset heeft dit metadata profiel tevens een optionele set.
-  - *De bron bevat een uitgebreide tabel (hoofdstuk 5.1) met verplichte (V), conditionele (C) en optionele elementen voor Nederlandse geodatasets, wat de claim volledig ondersteunt.*
+  > In de volgende tabel staan de verplichte of bij conditie verplichte elementen. Bij elk conditioneel element is de conditie benoemd. [...] Naast de verplichte kernset heeft dit metadata profiel tevens een optionele set.
+  - *De bron bevat een uitgebreide tabel (hoofdstuk 5.1) met verplichte (V), conditionele (C) en optionele elementen, en hoofdstuk 6 beschrijft de optionele set expliciet. Dit ondersteunt de claim volledig.*
+
+### `geo-meta-0053` — SKILL.md:210 *(§ Samenhang metadata standaarden)*
+
+> MDTO (Metagegevens Duurzaam Toegankelijke Overheidsinformatie) gaat uit van informatie-objecten en bestanden, terwijl DCAT en ISO 19115 werken met datasets en distributies.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MDTO, DCAT, ISO 19115, samenhang metadata standaarden
+
+- **SUPPORTED** (high) — [https://www.geonovum.nl/geo-standaarden/metadataprofiel-dcat-ap-nl/relaties-verschillende-metadata-standaarden](https://www.geonovum.nl/geo-standaarden/metadataprofiel-dcat-ap-nl/relaties-verschillende-metadata-standaarden)
+  > MDTO gaat uit van informatieobjecten en DCAT en ISO 19115 van datasets [...] MDTO gaat uit van bestanden en DCAT en ISO 19115 van distributies
 
 </details>

--- a/skills/geo-meta/audit.md
+++ b/skills/geo-meta/audit.md
@@ -1,0 +1,642 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo-meta — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 19 | 34% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 1 | 2% |
+| UNGROUNDED | 34 | 61% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 2 | 4% |
+
+*Geverifieerd met sonnet, 5 calls, $0.5966.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (19)
+
+### `geo-meta-0002` — SKILL.md:22 *(§ Metadata voor Geodata)*
+
+> Het Nationaal Georegister (NGR) is het centrale portaal voor het zoeken en publiceren van metadata over Nederlandse geodatasets en -services.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — Nationaal Georegister
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
+  - *De brontekst bevat geen vermelding van het Nationaal Georegister (NGR) als centraal portaal.*
+
+### `geo-meta-0014` — SKILL.md:149 *(§ CSW (Catalogue Service for the Web))*
+
+> CSW 2.0.2 is het OGC-protocol voor het zoeken en harvesten van metadata.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CSW — Catalogue Service for the Web
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over CSW 2.0.2.*
+
+### `geo-meta-0015` — SKILL.md:153 *(§ CSW (Catalogue Service for the Web))*
+
+> Het NGR biedt een CSW-endpoint op https://www.nationaalgeoregister.nl/geonetwork/srv/dut/csw.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — CSW-endpoint
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over het NGR CSW-endpoint.*
+
+### `geo-meta-0017` — SKILL.md:198 *(§ DCAT voor Geodata)*
+
+> GeoDCAT-AP biedt een mapping van ISO 19115 naar DCAT.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP.*
+
+### `geo-meta-0018` — SKILL.md:198 *(§ DCAT voor Geodata)*
+
+> DCAT-AP-NL is het Nederlandse profiel op DCAT-AP.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over DCAT-AP-NL.*
+
+### `geo-meta-0019` — SKILL.md:216 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Titel' mapt naar DCAT property `dct:title`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0020` — SKILL.md:217 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Samenvatting' mapt naar DCAT property `dct:description`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0021` — SKILL.md:218 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Verantwoordelijke organisatie' mapt naar DCAT property `dct:publisher`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0022` — SKILL.md:219 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Trefwoorden' mapt naar DCAT property `dcat:keyword`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0023` — SKILL.md:220 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Datum (publicatie)' mapt naar DCAT property `dct:issued`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0024` — SKILL.md:221 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Distributie (URL)' mapt naar DCAT property `dcat:distribution`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0025` — SKILL.md:222 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Ruimtelijke dekking (bbox)' mapt naar DCAT property `dct:spatial`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0026` — SKILL.md:223 *(§ Verhouding ISO 19115 en DCAT)*
+
+> ISO 19115 element 'Temporele dekking' mapt naar DCAT property `dct:temporal`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP — ISO 19115 naar DCAT mapping
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP mappings.*
+
+### `geo-meta-0051` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
+
+> DCAT-AP profielen worden gedefinieerd in SHACL; DCAT-AP-NL bouwt voort op de SHACL-shapes van DCAT-AP met aanvullende Nederlandse regels.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — SHACL validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over SHACL-validatie voor DCAT-AP-NL.*
+
+### `geo-meta-0052` — reference.md:110 *(§ DCAT metadata (SHACL-validatie))*
+
+> Er zijn meerdere validatieniveaus voor DCAT-AP-NL: alleen verplichte eigenschappen, aanbevolen eigenschappen, of inclusief HVD-eisen (High-Value Datasets).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — SHACL validatie niveaus
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over validatieniveaus voor DCAT-AP-NL.*
+
+### `geo-meta-0053` — reference.md:183 *(§ DCAT en GeoDCAT-AP)*
+
+> GeoDCAT-AP is een Europees profiel dat ISO 19115 metadata mapt naar DCAT (RDF), relevant voor koppeling met data.overheid.nl en het Europese data-portaal.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GeoDCAT-AP
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over GeoDCAT-AP.*
+
+### `geo-meta-0054` — SKILL.md:85 *(§ Voorbeeld Metadata XML (NL profiel))*
+
+> Het NL profiel op ISO 19115 heeft versienummer 2.1.0 (`metadataStandardVersion`).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115 — versie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over versienummer van het NL profiel op ISO 19115.*
+
+### `geo-meta-0055` — reference.md:163 *(§ Optie C: GeoNetwork REST API)*
+
+> Metadata uploaden via de GeoNetwork REST API kan via PUT op https://www.nationaalgeoregister.nl/geonetwork/srv/api/records met een X-XSRF-TOKEN header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NGR — GeoNetwork REST API publicatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/md met alleen bestandsnamen en datums. Er staat niets over GeoNetwork REST API, PUT-requests, of X-XSRF-TOKEN headers.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De aangeleverde brontekst is een directory-listing van docs.geostandaarden.nl/mim en bevat geen informatie over de GeoNetwork REST API, PUT-endpoints of X-XSRF-TOKEN headers.*
+
+### `geo-meta-0056` — reference.md:134 *(§ DCAT metadata (SHACL-validatie))*
+
+> DCAT metadata maakt gebruik van URI's naar externe registraties, zoals TOOI URI's voor overheidsorganisaties; bij validatie zijn externe URI-verwijzingen niet altijd te controleren zonder ze te volgen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DCAT-AP-NL — validatie beperkingen
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/md met alleen bestandsnamen en datums. Er staat niets over DCAT-AP-NL, URI-validatie, of TOOI URI's.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De aangeleverde brontekst is een directory-listing van docs.geostandaarden.nl/mim en bevat geen informatie over DCAT-AP-NL, URI-validatie of TOOI URI's voor overheidsorganisaties.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `geo-meta-0001` — SKILL.md:20 *(§ Metadata voor Geodata)*
+
+> Metadata (ISO 19115/19119) is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115/19119 — Forum Standaardisatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
+  > Beide profielen staan op de Pas-toe-of-leg-uit-lijst van het College Standaardisatie.
+  - *De bron bevestigt dat beide profielen (ISO 19115 en ISO 19119) op de pas-toe-of-leg-uit-lijst staan, maar noemt het 'College Standaardisatie', niet het 'Forum Standaardisatie'. Dit kan dezelfde instantie zijn onder een andere naam, maar de bron gebruikt expliciet 'College Standaardisatie'.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (34)
+
+### `geo-meta-0004` — SKILL.md:28 *(§ Standaarden Overzicht)*
+
+> ISO 19115:2003/19115-1:2014 heeft Forum Standaardisatie status 'Verplicht' voor beschrijving van datasets.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115 — Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is een directory-index van docs.geostandaarden.nl/md/ met alleen bestandsnamen en datums. Geen inhoud over Forum Standaardisatie-statussen.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/ op docs.geostandaarden.nl. Bevat geen informatie over Forum Standaardisatie-status van ISO 19115.*
+
+### `geo-meta-0005` — SKILL.md:29 *(§ Standaarden Overzicht)*
+
+> ISO 19119:2005 heeft Forum Standaardisatie status 'Verplicht' voor beschrijving van services.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst bevat alleen een directory-listing. Geen informatie over Forum Standaardisatie-status van ISO 19119.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over Forum Standaardisatie-status van ISO 19119.*
+
+### `geo-meta-0006` — SKILL.md:30 *(§ Standaarden Overzicht)*
+
+> Het NL profiel op ISO 19115 heeft Forum Standaardisatie status 'Verplicht'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst bevat alleen een directory-listing. Geen informatie over Forum Standaardisatie-status van het NL profiel.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over Forum Standaardisatie-status van het NL profiel op ISO 19115.*
+
+### `geo-meta-0007` — SKILL.md:32 *(§ Standaarden Overzicht)*
+
+> DCAT-AP-NL heeft Forum Standaardisatie status 'Aanbevolen' voor geodata-metadata.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DCAT-AP-NL — Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst bevat alleen een directory-listing. Geen informatie over DCAT-AP-NL of Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over DCAT-AP-NL.*
+
+### `geo-meta-0009` — SKILL.md:54 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element 'Trefwoorden' vereist minstens 1 trefwoord (`identificationInfo/descriptiveKeywords`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over verplichte elementen in het NL profiel op ISO 19115.*
+
+### `geo-meta-0010` — SKILL.md:56 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element 'Ruimtelijk referentiesysteem' bevat het CRS, bijvoorbeeld EPSG:28992 (`referenceSystemInfo`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over referenceSystemInfo of CRS-eisen.*
+
+### `geo-meta-0011` — SKILL.md:58 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element 'Taal' geeft de taal van de dataset aan als 'dut' of 'nld' (`identificationInfo/language`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over taal-elementen in het NL profiel.*
+
+### `geo-meta-0012` — SKILL.md:63 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element 'Metadata-standaard' heeft de waarde 'ISO 19115' (`metadataStandardName`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadataStandardName.*
+
+### `geo-meta-0013` — SKILL.md:65 *(§ Verplichte elementen (dataset))*
+
+> Het verplichte element 'Metadata-taal' heeft de waarde 'dut' of 'nld' (`language`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — dataset metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadata-taal.*
+
+### `geo-meta-0016` — SKILL.md:233 *(§ Veelvoorkomende Problemen)*
+
+> In CSW CQL-syntax wordt het procent-teken (%) gebruikt als wildcard bij `AnyText like '%term%'`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** CSW — CQL query syntax
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over CSW CQL-syntax.*
+
+### `geo-meta-0027` — SKILL.md:232 *(§ Veelvoorkomende Problemen)*
+
+> Om metadata vindbaar te maken voor INSPIRE moeten INSPIRE-trefwoorden (GEMET thesaurus) worden toegevoegd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** INSPIRE — metadata trefwoorden
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over INSPIRE-trefwoorden of GEMET thesaurus.*
+
+### `geo-meta-0028` — reference.md:11 *(§ Dataset Metadata)*
+
+> Het element `fileIdentifier` is verplicht, niet herhaalbaar, en bevat een unieke UUID van het metadata-record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over fileIdentifier.*
+
+### `geo-meta-0029` — reference.md:12 *(§ Dataset Metadata)*
+
+> Het element `language` (metadata-taal) is verplicht en niet herhaalbaar; waarde is 'dut' of 'nld'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadata-taal element.*
+
+### `geo-meta-0030` — reference.md:13 *(§ Dataset Metadata)*
+
+> Het element `characterSet` is conditioneel en niet herhaalbaar; de standaardwaarde is 'utf8'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over characterSet.*
+
+### `geo-meta-0031` — reference.md:14 *(§ Dataset Metadata)*
+
+> Het element `hierarchyLevel` is verplicht en niet herhaalbaar; mogelijke waarden zijn 'dataset', 'series' of 'service'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over hierarchyLevel.*
+
+### `geo-meta-0032` — reference.md:15 *(§ Dataset Metadata)*
+
+> Het element `contact` is verplicht en herhaalbaar; het bevat contactgegevens van de metadata-beheerder.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over contact-element.*
+
+### `geo-meta-0033` — reference.md:16 *(§ Dataset Metadata)*
+
+> Het element `dateStamp` is verplicht, niet herhaalbaar, en heeft het formaat YYYY-MM-DD.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over dateStamp.*
+
+### `geo-meta-0034` — reference.md:17 *(§ Dataset Metadata)*
+
+> Het element `metadataStandardName` is verplicht, niet herhaalbaar, en heeft de waarde 'ISO 19115'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over metadataStandardName.*
+
+### `geo-meta-0035` — reference.md:19 *(§ Dataset Metadata)*
+
+> Het element `referenceSystemInfo` is verplicht en herhaalbaar; het bevat het CRS, bijvoorbeeld EPSG:28992.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over referenceSystemInfo.*
+
+### `geo-meta-0036` — reference.md:21 *(§ Dataset Metadata)*
+
+> Het element `distributionInfo` is verplicht en niet herhaalbaar in het NL profiel op ISO 19115.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — volledige elementenlijst dataset
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over distributionInfo.*
+
+### `geo-meta-0037` — reference.md:35 *(§ Identificatie-elementen (MD_DataIdentification))*
+
+> Het identificatie-element `descriptiveKeywords` (trefwoorden) is verplicht en vereist minstens 1 trefwoord.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over descriptiveKeywords.*
+
+### `geo-meta-0038` — reference.md:36 *(§ Identificatie-elementen (MD_DataIdentification))*
+
+> Het identificatie-element `resourceConstraints` (gebruiksbeperkingen) is verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over resourceConstraints.*
+
+### `geo-meta-0039` — reference.md:38 *(§ Identificatie-elementen (MD_DataIdentification))*
+
+> Het identificatie-element `spatialResolution` (schaal of grondresolutie) is verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over spatialResolution.*
+
+### `geo-meta-0040` — reference.md:41 *(§ Identificatie-elementen (MD_DataIdentification))*
+
+> Het identificatie-element `topicCategory` (ISO-categorie) is verplicht en vereist minstens 1 categorie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over topicCategory.*
+
+### `geo-meta-0041` — reference.md:42 *(§ Identificatie-elementen (MD_DataIdentification))*
+
+> Het identificatie-element `extent` (ruimtelijke en temporele dekking) is verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — MD_DataIdentification
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over extent-element.*
+
+### `geo-meta-0042` — reference.md:66 *(§ Service Metadata (ISO 19119))*
+
+> Voor service metadata (ISO 19119) is het element `serviceType` verplicht; waarden zijn OGC:WMS, OGC:WFS, OGC:CSW, etc.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over serviceType voor ISO 19119.*
+
+### `geo-meta-0043` — reference.md:67 *(§ Service Metadata (ISO 19119))*
+
+> Voor service metadata is het element `serviceTypeVersion` (versie van het service-protocol) verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over serviceTypeVersion.*
+
+### `geo-meta-0044` — reference.md:68 *(§ Service Metadata (ISO 19119))*
+
+> Voor service metadata is het element `couplingType` verplicht; mogelijke waarden zijn 'tight', 'mixed' of 'loose'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over couplingType.*
+
+### `geo-meta-0045` — reference.md:69 *(§ Service Metadata (ISO 19119))*
+
+> Voor service metadata is het element `containsOperations` (operaties zoals GetCapabilities, GetMap) verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19119 — service metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over containsOperations.*
+
+### `geo-meta-0046` — reference.md:70 *(§ Service Metadata (ISO 19119))*
+
+> Voor service metadata is het element `operatesOn` (link naar dataset-metadata) conditioneel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** ISO 19119 — service metadata
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over operatesOn.*
+
+### `geo-meta-0047` — reference.md:77 *(§ Structurele validatie)*
+
+> Metadata moet voldoen aan het ISO 19115 XML-schema (gmd namespace) voor structurele validatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ISO 19115 — structurele validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over ISO 19115 XML-schema validatie.*
+
+### `geo-meta-0048` — reference.md:88 *(§ Inhoudelijke validatie (NL profiel))*
+
+> Bij inhoudelijke validatie (NL profiel) moet de samenvatting minimaal 25 tekens bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over inhoudelijke validatieregels.*
+
+### `geo-meta-0049` — reference.md:89 *(§ Inhoudelijke validatie (NL profiel))*
+
+> Bij inhoudelijke validatie moeten contactgegevens een organisatienaam en e-mailadres bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over contactgegevens-eisen.*
+
+### `geo-meta-0050` — reference.md:90 *(§ Inhoudelijke validatie (NL profiel))*
+
+> De bounding box moet binnen of gelijk aan Nederland vallen (lat: 50.75-53.47, lon: 3.37-7.21) of breder zijn.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nederlands profiel ISO 19115 — inhoudelijke validatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/md/](https://docs.geostandaarden.nl/md/)
+  - *De brontekst is uitsluitend een directory-index zonder specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De brontekst is een directorylijst van /mim/. Bevat geen informatie over bounding box-eisen.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (2)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-meta-0003` — SKILL.md:22 *(§ Metadata voor Geodata)*
+
+> Geonovum beheert het Nederlands profiel op ISO 19115/19119 als basis voor alle metadata.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115/19119
+
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
+  > Geonovum ontwikkelt en beheert de Nederlandse metadata profielen. Deze profielen zijn een verbijzondering van de internationale metadatastandaarden van ISO en zijn bedoeld om de interoperabiliteit binnen Nederland te bevorderen.
+
+### `geo-meta-0008` — SKILL.md:44 *(§ Nederlands Profiel ISO 19115)*
+
+> Het Nederlands profiel specificeert welke metadata-elementen verplicht, conditioneel of optioneel zijn voor Nederlandse geodatasets.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Nederlands profiel ISO 19115
+
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/md/mdprofiel-iso19115](https://docs.geostandaarden.nl/md/mdprofiel-iso19115)
+  > In de volgende tabel staan de verplichte of bij conditie verplichte elementen. [...] Naast de verplichte kernset heeft dit metadata profiel tevens een optionele set.
+  - *De bron bevat een uitgebreide tabel (hoofdstuk 5.1) met verplichte (V), conditionele (C) en optionele elementen voor Nederlandse geodatasets, wat de claim volledig ondersteunt.*
+
+</details>

--- a/skills/geo-model/audit.md
+++ b/skills/geo-model/audit.md
@@ -1,0 +1,765 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo-model — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 31 | 63% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 3 | 6% |
+| UNGROUNDED | 14 | 29% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 1 | 2% |
+
+*Geverifieerd met sonnet, 7 calls, $1.0492.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (31)
+
+### `geo-model-0005` — SKILL.md:28 *(§ Standaarden Overzicht)*
+
+> NEN 3610:2022 heeft Forum Standaardisatie status 'Verplicht'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  - *De brontekst is de technische specificatie van IMRO2012 zelf. Forum Standaardisatie-status van NEN 3610:2022 wordt nergens vermeld.*
+
+### `geo-model-0006` — SKILL.md:29 *(§ Standaarden Overzicht)*
+
+> MIM 1.2 heeft Forum Standaardisatie status 'Aanbevolen'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  - *MIM en Forum Standaardisatie-status worden niet behandeld in deze IMRO2012-specificatie.*
+
+### `geo-model-0007` — SKILL.md:30 *(§ Standaarden Overzicht)*
+
+> IMGeo 2.2 / BGT heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  - *IMGeo/BGT en Forum Standaardisatie-status worden niet behandeld in deze bron.*
+
+### `geo-model-0008` — SKILL.md:31 *(§ Standaarden Overzicht)*
+
+> IMBAG heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  - *IMBAG en Forum Standaardisatie-status worden niet behandeld in deze bron.*
+
+### `geo-model-0010` — SKILL.md:33 *(§ Standaarden Overzicht)*
+
+> IMKL heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  - *IMKL en Forum Standaardisatie-status worden niet behandeld in deze IMRO2012-specificatie.*
+
+### `geo-model-0011` — SKILL.md:47 *(§ NEN 3610 — Basismodel Geo-informatie)*
+
+> NEN 3610:2022 definieert de basisstructuur waar alle Nederlandse geo-informatiemodellen op voortbouwen, met GeoObject als basis, onderverdeeld in ReëelObject en VirtueleRuimte.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610:2022
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *De aangeleverde brontekst is een directory listing van docs.geostandaarden.nl/nen3610/ zonder inhoudelijke documentatie over NEN 3610:2022, GeoObject, ReëelObject of VirtueleRuimte.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/mim/ en bevat geen inhoudelijke informatie over NEN 3610:2022, GeoObject, ReëelObject of VirtueleRuimte.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *De aangeleverde brontekst is slechts een directory listing van docs.geostandaarden.nl/nl-sbb zonder inhoudelijke documentatie over NEN 3610:2022.*
+</details>
+
+### `geo-model-0012` — SKILL.md:47 *(§ NEN 3610 — Basismodel Geo-informatie)*
+
+> ReëelObject is tastbaar en waarneembaar; VirtueleRuimte is conceptueel en niet-tastbaar.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610:2022
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen inhoudelijke informatie over ReëelObject of VirtueleRuimte.*
+</details>
+
+### `geo-model-0017` — SKILL.md:76 *(§ Verplichte Eigenschappen van GeoObject)*
+
+> GeoObject heeft optionele eigenschappen 'eindRegistratie', 'eindGeldigheid' en 'domein'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, GeoObject
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+</details>
+
+### `geo-model-0018` — SKILL.md:86 *(§ NEN3610ID Structuur)*
+
+> NEN3610ID bestaat uit de velden namespace, lokaalID en versie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, NEN3610ID
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over NEN3610ID.*
+</details>
+
+### `geo-model-0020` — SKILL.md:144 *(§ MIM — Metamodel Informatie Modellering)*
+
+> MIM definieert vier modellagen: conceptueel model (niveau 1), logisch model (niveau 2), fysiek/technisch model (niveau 3), en data/instanties (niveau 4).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst. De URL verwijst naar de MIM-index maar bevat geen specificatie-inhoud.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over MIM-modellagen.*
+</details>
+
+### `geo-model-0021` — SKILL.md:155 *(§ MIM Modelelementen)*
+
+> MIM definieert modelelementen: Objecttype (UML Class), Attribuutsoort (UML Attribute), Relatiesoort (UML Association), Gegevensgroep (UML DataType), Enumeratie (UML Enumeration), en Keuze (UML Union).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over MIM-modelelementen.*
+</details>
+
+### `geo-model-0022` — SKILL.md:168 *(§ IMGeo / BGT (Grootschalige Topografie))*
+
+> De Basisregistratie Grootschalige Topografie (BGT) gebruikt het informatiemodel IMGeo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMGeo of BGT.*
+</details>
+
+### `geo-model-0023` — SKILL.md:194 *(§ URI-strategie voor Linked Data)*
+
+> Geonovum definieert een URI-strategie voor het publiceren van geo-objecten als linked data met het patroon: https://data.{domein}.nl/id/{objecttype}/{identificatie}.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, URI-strategie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over URI-strategie voor linked data.*
+</details>
+
+### `geo-model-0024` — reference.md:48 *(§ Temporeel Model)*
+
+> NEN 3610 ondersteunt bitemporeel modelleren via twee tijdassen: registratietijd (tijdstipRegistratie/eindRegistratie) en geldigheidstijd (beginGeldigheid/eindGeldigheid).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, temporeel model
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over bitemporeel modelleren in NEN 3610.*
+</details>
+
+### `geo-model-0025` — reference.md:55 *(§ Temporeel Model)*
+
+> Het bitemporale model van NEN 3610 maakt het mogelijk om de toestand van de registratie op elk moment in het verleden te reconstrueren (tijdreizen).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, temporeel model
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over het bitemporale model.*
+</details>
+
+### `geo-model-0027` — reference.md:92 *(§ Geometrietypen (ISO 19107))*
+
+> MIM gebruikt ISO 19107 geometrietypen: GM_Point (0D), GM_Curve (1D), GM_Surface (2D), GM_Solid (3D), en GM_Object (willekeurig).
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, ISO 19107, geometrietypen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over ISO 19107 geometrietypen.*
+</details>
+
+### `geo-model-0028` — reference.md:111 *(§ Basisregistraties)*
+
+> IMBAG is afgeleid van NEN 3610 en beheert de BAG (Adressen en Gebouwen) door het Kadaster.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG, BAG, NEN 3610
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMBAG of BAG.*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst is de homepage van developer.kadaster.nl en bevat geen informatie over IMBAG, NEN 3610 of de technische beheerstructuur van de BAG.*
+</details>
+
+### `geo-model-0029` — reference.md:112 *(§ Basisregistraties)*
+
+> IMGeo/BGT is afgeleid van NEN 3610 en wordt beheerd door Geonovum/SVB-BGT.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT, NEN 3610
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMGeo/BGT-beheer.*
+</details>
+
+### `geo-model-0030` — reference.md:113 *(§ Basisregistraties)*
+
+> IMBRT (BRT Topografie) is afgeleid van NEN 3610 en wordt beheerd door het Kadaster.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRT, BRT, NEN 3610
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMBRT of BRT.*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst bevat geen informatie over IMBRT, BRT Topografie of NEN 3610.*
+</details>
+
+### `geo-model-0031` — reference.md:114 *(§ Basisregistraties)*
+
+> IMBRO (BRO Ondergrond) is afgeleid van NEN 3610 en wordt beheerd door TNO.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRO, BRO, NEN 3610
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMBRO of BRO.*
+</details>
+
+### `geo-model-0032` — reference.md:115 *(§ Basisregistraties)*
+
+> IMKAD (BRK Kadaster) is afgeleid van NEN 3610 en wordt beheerd door het Kadaster.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKAD, BRK, NEN 3610
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMKAD of BRK.*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst bevat geen informatie over IMKAD, BRK of NEN 3610.*
+</details>
+
+### `geo-model-0033` — reference.md:121 *(§ Domeinmodellen)*
+
+> IMRO (Ruimtelijke Ordening) is afgeleid van NEN 3610 en wordt beheerd door Geonovum.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO, NEN 3610
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMRO.*
+</details>
+
+### `geo-model-0034` — reference.md:122 *(§ Domeinmodellen)*
+
+> IMKL (Kabels en Leidingen) is afgeleid van NEN 3610 en wordt beheerd door Kadaster/KLIC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL, NEN 3610
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMKL.*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst bevat geen informatie over IMKL, kabels en leidingen, of NEN 3610.*
+</details>
+
+### `geo-model-0035` — reference.md:127 *(§ Domeinmodellen)*
+
+> IMBOR (Beheer Openbare Ruimte) is slechts gedeeltelijk afgeleid van NEN 3610 en wordt beheerd door CROW.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBOR, NEN 3610
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over IMBOR.*
+</details>
+
+### `geo-model-0036` — reference.md:131 *(§ Relatie tussen Sectormodellen en NEN 3610)*
+
+> Elk sectormodel breidt NEN 3610 uit door objecttypen te specialiseren via overerving van GeoObject, domein-specifieke attributen toe te voegen, waardelijsten te definiëren en domein-specifieke relaties te leggen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, sectormodellen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over sectormodellen en overerving van GeoObject.*
+</details>
+
+### `geo-model-0037` — reference.md:142 *(§ NEN 3610 Ontologie)*
+
+> De NEN 3610 ontologie is beschikbaar als RDF/OWL en is gepubliceerd onder de namespace https://definities.geostandaarden.nl/nen3610-2022/nl/.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, RDF/OWL
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over de NEN 3610 RDF/OWL ontologie.*
+</details>
+
+### `geo-model-0038` — reference.md:151 *(§ NEN 3610 Ontologie)*
+
+> In de NEN 3610 ontologie is GeoObject een subklasse van geo:Feature (GeoSPARQL).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, GeoSPARQL
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over GeoSPARQL of geo:Feature.*
+</details>
+
+### `geo-model-0040` — reference.md:202 *(§ Enterprise Architect)*
+
+> Enterprise Architect (Sparx Systems) is de standaardtool voor het opstellen van MIM-conforme informatiemodellen; er is een MIM-profiel beschikbaar.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, tooling
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over Enterprise Architect of MIM-tooling.*
+</details>
+
+### `geo-model-0041` — reference.md:206 *(§ Imvertor)*
+
+> Imvertor transformeert UML-modellen naar XSD (GML application schema), JSON Schema, RDF/SKOS/SHACL en HTML-documentatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, Imvertor, tooling
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over Imvertor.*
+</details>
+
+### `geo-model-0042` — reference.md:214 *(§ ShapeChange)*
+
+> ShapeChange (interactive instruments) is een alternatieve tool voor het genereren van GML application schema's uit UML-modellen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, ShapeChange, tooling
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over ShapeChange.*
+</details>
+
+### `geo-model-0049` — reference.md:67 *(§ Stereotypen)*
+
+> MIM onderscheidt stereotype <<codelijst>> als uitbreidbare waardelijst (dynamische waardelijsten) naast <<enumeratie>> als vaste waardelijst.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, stereotypen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over MIM-stereotypen.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (3)
+
+### `geo-model-0002` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
+
+> NEN 3610 is het basismodel voor geo-informatie in Nederland. Alle sectorale informatiemodellen (IMGeo, IMBAG, IMRO, etc.) zijn hiervan afgeleid.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+  > ze kunnen als basis gebruikt worden voor (bij voorkeur model-driven generatie van) afgeleide modellen en producten voor een specifiek toepassingsgebied/domein zoals bijvoorbeeld [ NEN3610 ] of het gemeentelijke domein
+  - *De bron bevestigt dat NEN 3610 een normatieve referentie is en als voorbeeld van een domeinspecifiek toepassingsgebied wordt genoemd, maar omschrijft MIM als het basismodel — niet NEN 3610. Dat NEN 3610 het basismodel voor geo-informatie in Nederland is en dat IMBAG, IMRO etc. daarvan zijn afgeleid, staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
+  - *De brontekst is uitsluitend een bestandsindex (directory listing). Er staat geen inhoud over NEN 3610 als basismodel of afgeleide sectorale modellen.*
+
+### `geo-model-0004` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
+
+> Geonovum beheert zowel NEN 3610 als MIM.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, MIM
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+  > Het beheer van dit metamodel vindt plaats door Geonovum met ondersteuning van het Kadaster.
+  - *De bron bevestigt dat Geonovum MIM beheert. Dat Geonovum ook NEN 3610 beheert staat niet in deze bron; NEN 3610 wordt alleen als normatieve referentie vermeld.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
+  - *De brontekst bevat geen informatie over Geonovum als beheerder van NEN 3610 of MIM.*
+
+### `geo-model-0009` — SKILL.md:32 *(§ Standaarden Overzicht)*
+
+> IMRO heeft Forum Standaardisatie status 'Verplicht (als sectormodel)' en licentie CC-BY-ND-4.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO, Forum Standaardisatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
+  > Dit document valt onder de volgende licentie: Creative Commons Naamsvermelding-GeenAfgeleideWerken 4.0 Internationaal
+  - *De licentie CC-BY-ND-4.0 wordt bevestigd door de metadata van het document. De Forum Standaardisatie-status 'Verplicht (als sectormodel)' wordt nergens in de brontekst vermeld.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (14)
+
+### `geo-model-0001` — SKILL.md:20 *(§ Informatiemodellen voor Geodata)*
+
+> NEN 3610 is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/nen3610 en bevat geen inhoudelijke informatie over verplichtingstatus of Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+  - *De brontekst behandelt MIM uitgebreid maar vermeldt nergens de 'pas-toe-of-leg-uit'-verplichting van het Forum Standaardisatie voor NEN 3610.*
+
+### `geo-model-0013` — SKILL.md:75 *(§ Verplichte Eigenschappen van GeoObject)*
+
+> GeoObject heeft de verplichte eigenschap 'identificatie' van type NEN3610ID (unieke identificatie bestaande uit namespace, lokaalId en versie).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst is een directory listing zonder inhoudelijke specificaties.*
+</details>
+
+### `geo-model-0014` — SKILL.md:77 *(§ Verplichte Eigenschappen van GeoObject)*
+
+> GeoObject heeft de verplichte eigenschap 'tijdstipRegistratie' van type DateTime.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+</details>
+
+### `geo-model-0015` — SKILL.md:79 *(§ Verplichte Eigenschappen van GeoObject)*
+
+> GeoObject heeft de verplichte eigenschap 'beginGeldigheid' van type DateTime.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+</details>
+
+### `geo-model-0016` — SKILL.md:81 *(§ Verplichte Eigenschappen van GeoObject)*
+
+> GeoObject heeft de verplichte eigenschap 'geometrie' van type GM_Object.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+</details>
+
+### `geo-model-0019` — SKILL.md:211 *(§ Veelvoorkomende Problemen)*
+
+> Voor geodata in Nederland moet EPSG:28992 als coördinatenreferentiestelsel worden gebruikt en gespecificeerd via srsName in GML.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GML, geometrie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over coördinatenreferentiestelsels of GML.*
+</details>
+
+### `geo-model-0026` — reference.md:77 *(§ Naamgevingsregels)*
+
+> MIM schrijft voor dat Objecttype-namen UpperCamelCase enkelvoud zijn, attribuutsoort-namen lowerCamelCase, en relatiesoort-namen lowerCamelCase werkwoorden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** MIM, naamgevingsregels
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over MIM-naamgevingsregels.*
+</details>
+
+### `geo-model-0039` — reference.md:186 *(§ URI Dereferencing)*
+
+> Voor een werkende linked data-implementatie van geo-objecten is content negotiation vereist met 303 See Other redirects.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, Linked Data, URI dereferencing
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over content negotiation of 303-redirects.*
+</details>
+
+### `geo-model-0043` — reference.md:19 *(§ Basisklassen)*
+
+> NEN 3610 GeoObject heeft attribuut 'geometrie' met cardinaliteit [1..*] (verplicht, 1 of meer).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+</details>
+
+### `geo-model-0044` — reference.md:13 *(§ Basisklassen)*
+
+> NEN 3610 GeoObject heeft attribuut 'identificatie' met cardinaliteit [1..1] (verplicht, precies 1).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+</details>
+
+### `geo-model-0045` — reference.md:15 *(§ Basisklassen)*
+
+> NEN 3610 GeoObject heeft attribuut 'tijdstipRegistratie' met cardinaliteit [1..1] (verplicht, precies 1).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+</details>
+
+### `geo-model-0046` — reference.md:17 *(§ Basisklassen)*
+
+> NEN 3610 GeoObject heeft attribuut 'beginGeldigheid' met cardinaliteit [1..1] (verplicht, precies 1).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+</details>
+
+### `geo-model-0047` — reference.md:22 *(§ Basisklassen)*
+
+> NEN3610ID heeft namespace en lokaalID als verplichte velden ([1..1]) en versie als optioneel veld ([0..1]).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, NEN3610ID, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over NEN3610ID-cardinaliteiten.*
+</details>
+
+### `geo-model-0048` — reference.md:40 *(§ Specialisaties van GeoObject (NEN 3610:2022))*
+
+> FunctioneleRuimte (specialisatie van VirtueleRuimte) heeft attribuut 'functie' met cardinaliteit [1..1] (verplicht).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, VirtueleRuimte, UML
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Aangeleverde brontekst bevat geen informatie over FunctioneleRuimte of VirtueleRuimte.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (1)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-model-0003` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
+
+> Het Metamodel Informatie Modellering (MIM) beschrijft hoe informatiemodellen opgesteld moeten worden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+  > Met MIM, het Metamodel voor Informatie Modellering, wordt een metamodel beschreven waar informatiemodellen mee gemaakt kunnen worden. Het beschrijft de metaklassen, metastructuur en metagegevens als grondslag voor een informatiemodel. Doel hiervan is standaardiseren van de methode van informatiemodelleren
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
+  - *De brontekst bevat geen informatie over MIM of het Metamodel Informatie Modellering.*
+
+</details>

--- a/skills/geo-model/audit.md
+++ b/skills/geo-model/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo-model — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,486 +7,518 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 31 | 63% |
+| UNSUPPORTED_ASSERTION | 33 | 66% |
 | CONTRADICTED | 0 | 0% |
 | PARTIALLY_GROUNDED | 3 | 6% |
-| UNGROUNDED | 14 | 29% |
+| UNGROUNDED | 13 | 26% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
 | GROUNDED | 1 | 2% |
 
-*Geverifieerd met sonnet, 7 calls, $1.0492.*
+*Geverifieerd met sonnet, 9 calls, $1.1385.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (31)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (33)
 
-### `geo-model-0005` — SKILL.md:28 *(§ Standaarden Overzicht)*
+### `geo-model-0004` — SKILL.md:28 *(§ Standaarden Overzicht)*
 
 > NEN 3610:2022 heeft Forum Standaardisatie status 'Verplicht'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
-  - *De brontekst is de technische specificatie van IMRO2012 zelf. Forum Standaardisatie-status van NEN 3610:2022 wordt nergens vermeld.*
+  - *De brontekst is de IMRO2012 specificatie zelf. Forum Standaardisatie status van NEN 3610:2022 wordt nergens in deze bron vermeld.*
 
-### `geo-model-0006` — SKILL.md:29 *(§ Standaarden Overzicht)*
+### `geo-model-0005` — SKILL.md:29 *(§ Standaarden Overzicht)*
 
 > MIM 1.2 heeft Forum Standaardisatie status 'Aanbevolen'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
-  - *MIM en Forum Standaardisatie-status worden niet behandeld in deze IMRO2012-specificatie.*
+  - *MIM of Forum Standaardisatie status wordt niet behandeld in deze bron.*
 
-### `geo-model-0007` — SKILL.md:30 *(§ Standaarden Overzicht)*
+### `geo-model-0006` — SKILL.md:30 *(§ Standaarden Overzicht)*
 
 > IMGeo 2.2 / BGT heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo / BGT / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
-  - *IMGeo/BGT en Forum Standaardisatie-status worden niet behandeld in deze bron.*
+  - *IMGeo / BGT en Forum Standaardisatie status komen niet voor in deze bron.*
 
-### `geo-model-0008` — SKILL.md:31 *(§ Standaarden Overzicht)*
+### `geo-model-0007` — SKILL.md:31 *(§ Standaarden Overzicht)*
 
 > IMBAG heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
-  - *IMBAG en Forum Standaardisatie-status worden niet behandeld in deze bron.*
+  - *IMBAG en Forum Standaardisatie status komen niet voor in deze bron.*
 
-### `geo-model-0010` — SKILL.md:33 *(§ Standaarden Overzicht)*
+### `geo-model-0009` — SKILL.md:33 *(§ Standaarden Overzicht)*
 
 > IMKL heeft Forum Standaardisatie status 'Verplicht (als sectormodel)'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
-  - *IMKL en Forum Standaardisatie-status worden niet behandeld in deze IMRO2012-specificatie.*
+  - *IMKL en Forum Standaardisatie status komen niet voor in deze bron.*
 
-### `geo-model-0011` — SKILL.md:47 *(§ NEN 3610 — Basismodel Geo-informatie)*
+### `geo-model-0010` — SKILL.md:47 *(§ NEN 3610 — Basismodel Geo-informatie)*
 
-> NEN 3610:2022 definieert de basisstructuur waar alle Nederlandse geo-informatiemodellen op voortbouwen, met GeoObject als basis, onderverdeeld in ReëelObject en VirtueleRuimte.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610:2022
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *De aangeleverde brontekst is een directory listing van docs.geostandaarden.nl/nen3610/ zonder inhoudelijke documentatie over NEN 3610:2022, GeoObject, ReëelObject of VirtueleRuimte.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/mim/ en bevat geen inhoudelijke informatie over NEN 3610:2022, GeoObject, ReëelObject of VirtueleRuimte.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *De aangeleverde brontekst is slechts een directory listing van docs.geostandaarden.nl/nl-sbb zonder inhoudelijke documentatie over NEN 3610:2022.*
-</details>
-
-### `geo-model-0012` — SKILL.md:47 *(§ NEN 3610 — Basismodel Geo-informatie)*
-
-> ReëelObject is tastbaar en waarneembaar; VirtueleRuimte is conceptueel en niet-tastbaar.
+> NEN 3610:2022 definieert de basisstructuur met GeoObject als basis, onderverdeeld in ReëelObject (tastbaar, waarneembaar) en VirtueleRuimte (conceptueel, niet-tastbaar).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610:2022
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *De brontekst is een directory-listing van docs.geostandaarden.nl/nen3610 zonder inhoudelijke informatie over NEN 3610:2022 of GeoObject/ReëelObject/VirtueleRuimte.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/mim en bevat geen inhoudelijke informatie over NEN 3610:2022 of de basisstructuur met GeoObject, ReëelObject en VirtueleRuimte.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen inhoudelijke informatie over ReëelObject of VirtueleRuimte.*
+  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/nl-sbb en bevat geen inhoudelijke informatie over NEN 3610:2022 of GeoObject.*
 </details>
 
-### `geo-model-0017` — SKILL.md:76 *(§ Verplichte Eigenschappen van GeoObject)*
+### `geo-model-0015` — SKILL.md:75 *(§ Verplichte Eigenschappen van GeoObject)*
 
-> GeoObject heeft optionele eigenschappen 'eindRegistratie', 'eindGeldigheid' en 'domein'.
+> NEN3610ID bestaat uit de componenten namespace, lokaalID en versie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, GeoObject
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 NEN3610ID
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0018` — SKILL.md:86 *(§ NEN3610ID Structuur)*
+### `geo-model-0017` — SKILL.md:144 *(§ MIM — Metamodel Informatie Modellering)*
 
-> NEN3610ID bestaat uit de velden namespace, lokaalID en versie.
+> MIM definieert vier modellagen: Niveau 1 Conceptueel model, Niveau 2 Logisch model, Niveau 3 Fysiek/technisch model, Niveau 4 Data/instanties.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, NEN3610ID
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM metamodel
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie over MIM-modellagen.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over NEN3610ID.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0020` — SKILL.md:144 *(§ MIM — Metamodel Informatie Modellering)*
+### `geo-model-0018` — SKILL.md:157 *(§ MIM Modelelementen)*
 
-> MIM definieert vier modellagen: conceptueel model (niveau 1), logisch model (niveau 2), fysiek/technisch model (niveau 3), en data/instanties (niveau 4).
+> MIM-element 'Objecttype' correspondeert met UML Class.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM modelelementen
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst. De URL verwijst naar de MIM-index maar bevat geen specificatie-inhoud.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over MIM-modellagen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0021` — SKILL.md:155 *(§ MIM Modelelementen)*
+### `geo-model-0019` — SKILL.md:158 *(§ MIM Modelelementen)*
 
-> MIM definieert modelelementen: Objecttype (UML Class), Attribuutsoort (UML Attribute), Relatiesoort (UML Association), Gegevensgroep (UML DataType), Enumeratie (UML Enumeration), en Keuze (UML Union).
+> MIM-element 'Attribuutsoort' correspondeert met UML Attribute.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM modelelementen
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over MIM-modelelementen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
+</details>
+
+### `geo-model-0020` — SKILL.md:159 *(§ MIM Modelelementen)*
+
+> MIM-element 'Relatiesoort' correspondeert met UML Association.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM modelelementen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
+</details>
+
+### `geo-model-0021` — SKILL.md:161 *(§ MIM Modelelementen)*
+
+> MIM-element 'Enumeratie' correspondeert met UML Enumeration.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM modelelementen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
 ### `geo-model-0022` — SKILL.md:168 *(§ IMGeo / BGT (Grootschalige Topografie))*
 
-> De Basisregistratie Grootschalige Topografie (BGT) gebruikt het informatiemodel IMGeo.
+> De BGT (Basisregistratie Grootschalige Topografie) gebruikt het informatiemodel IMGeo.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BGT / IMGeo
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMGeo of BGT.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
 ### `geo-model-0023` — SKILL.md:194 *(§ URI-strategie voor Linked Data)*
 
-> Geonovum definieert een URI-strategie voor het publiceren van geo-objecten als linked data met het patroon: https://data.{domein}.nl/id/{objecttype}/{identificatie}.
+> Geonovum definieert een URI-strategie voor geo-objecten als linked data met patroon: https://data.{domein}.nl/id/{objecttype}/{identificatie}.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, URI-strategie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over URI-strategie voor linked data.*
-</details>
-
-### `geo-model-0024` — reference.md:48 *(§ Temporeel Model)*
-
-> NEN 3610 ondersteunt bitemporeel modelleren via twee tijdassen: registratietijd (tijdstipRegistratie/eindRegistratie) en geldigheidstijd (beginGeldigheid/eindGeldigheid).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, temporeel model
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 Linked Data URI-strategie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over bitemporeel modelleren in NEN 3610.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0025` — reference.md:55 *(§ Temporeel Model)*
+### `geo-model-0028` — reference.md:48 *(§ Temporeel Model)*
 
-> Het bitemporale model van NEN 3610 maakt het mogelijk om de toestand van de registratie op elk moment in het verleden te reconstrueren (tijdreizen).
+> NEN 3610 ondersteunt bitemporeel modelleren met twee tijdassen: registratietijd (tijdstipRegistratie/eindRegistratie) en geldigheidstijd (beginGeldigheid/eindGeldigheid).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, temporeel model
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 temporeel model
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over het bitemporale model.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0027` — reference.md:92 *(§ Geometrietypen (ISO 19107))*
+### `geo-model-0029` — reference.md:55 *(§ Temporeel Model)*
 
-> MIM gebruikt ISO 19107 geometrietypen: GM_Point (0D), GM_Curve (1D), GM_Surface (2D), GM_Solid (3D), en GM_Object (willekeurig).
+> Het bitemporele model van NEN 3610 maakt het mogelijk om de toestand van de registratie op elk moment in het verleden te reconstrueren (tijdreizen).
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, ISO 19107, geometrietypen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 temporeel model
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over ISO 19107 geometrietypen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0028` — reference.md:111 *(§ Basisregistraties)*
+### `geo-model-0030` — reference.md:63 *(§ Stereotypen)*
 
-> IMBAG is afgeleid van NEN 3610 en beheert de BAG (Adressen en Gebouwen) door het Kadaster.
+> MIM-stereotype <<objecttype>> wordt gebruikt voor klassen van objecten met identiteit, als hoofdobjecten in het model.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG, BAG, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM stereotypen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
+</details>
+
+### `geo-model-0031` — reference.md:68 *(§ Stereotypen)*
+
+> MIM-stereotype <<codelijst>> vertegenwoordigt een uitbreidbare (dynamische) waardelijst, in tegenstelling tot <<enumeratie>> die een vaste waardelijst is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM stereotypen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
+</details>
+
+### `geo-model-0035` — reference.md:96 *(§ Geometrietypen (ISO 19107))*
+
+> Geometrietype GM_Point is 0-dimensioneel (punt), GM_Curve is 1-dimensioneel (lijn), GM_Surface is 2-dimensioneel (vlak), GM_Solid is 3-dimensioneel (volume) conform ISO 19107.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM / ISO 19107 geometrietypen
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
+</details>
+
+### `geo-model-0036` — reference.md:111 *(§ Basisregistraties)*
+
+> IMBAG is het sectormodel voor de Basisregistratie Adressen en Gebouwen (BAG), beheerd door Kadaster, afgeleid van NEN 3610.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBAG sectormodel
 
 <details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMBAG of BAG.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst is de homepage van developer.kadaster.nl en bevat geen informatie over IMBAG, NEN 3610 of de technische beheerstructuur van de BAG.*
+  - *De brontekst is een algemene ontwikkelaarspagina van Kadaster zonder inhoud over IMBAG, NEN 3610 of sectormodellen.*
 </details>
 
-### `geo-model-0029` — reference.md:112 *(§ Basisregistraties)*
+### `geo-model-0037` — reference.md:112 *(§ Basisregistraties)*
 
-> IMGeo/BGT is afgeleid van NEN 3610 en wordt beheerd door Geonovum/SVB-BGT.
+> IMGeo/BGT is het sectormodel voor de Basisregistratie Grootschalige Topografie, beheerd door Geonovum/SVB-BGT, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo, BGT, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo/BGT sectormodel
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMGeo/BGT-beheer.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0030` — reference.md:113 *(§ Basisregistraties)*
+### `geo-model-0038` — reference.md:113 *(§ Basisregistraties)*
 
-> IMBRT (BRT Topografie) is afgeleid van NEN 3610 en wordt beheerd door het Kadaster.
+> IMBRT is het sectormodel voor de Basisregistratie Topografie (BRT), beheerd door Kadaster, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRT, BRT, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRT sectormodel
 
 <details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMBRT of BRT.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst bevat geen informatie over IMBRT, BRT Topografie of NEN 3610.*
+  - *De brontekst bevat geen informatie over IMBRT, BRT als sectormodel, of NEN 3610.*
 </details>
 
-### `geo-model-0031` — reference.md:114 *(§ Basisregistraties)*
+### `geo-model-0039` — reference.md:114 *(§ Basisregistraties)*
 
-> IMBRO (BRO Ondergrond) is afgeleid van NEN 3610 en wordt beheerd door TNO.
+> IMBRO is het sectormodel voor de Basisregistratie Ondergrond (BRO), beheerd door TNO, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRO, BRO, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBRO sectormodel
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMBRO of BRO.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0032` — reference.md:115 *(§ Basisregistraties)*
+### `geo-model-0040` — reference.md:115 *(§ Basisregistraties)*
 
-> IMKAD (BRK Kadaster) is afgeleid van NEN 3610 en wordt beheerd door het Kadaster.
+> IMKAD is het sectormodel voor de Basisregistratie Kadaster (BRK), beheerd door Kadaster, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKAD, BRK, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKAD sectormodel
 
 <details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMKAD of BRK.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst bevat geen informatie over IMKAD, BRK of NEN 3610.*
+  - *De brontekst bevat geen informatie over IMKAD, BRK als sectormodel, of NEN 3610.*
 </details>
 
-### `geo-model-0033` — reference.md:121 *(§ Domeinmodellen)*
+### `geo-model-0041` — reference.md:121 *(§ Domeinmodellen)*
 
-> IMRO (Ruimtelijke Ordening) is afgeleid van NEN 3610 en wordt beheerd door Geonovum.
+> IMRO is het sectormodel voor Ruimtelijke Ordening, beheerd door Geonovum, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO sectormodel
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMRO.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0034` — reference.md:122 *(§ Domeinmodellen)*
+### `geo-model-0042` — reference.md:122 *(§ Domeinmodellen)*
 
-> IMKL (Kabels en Leidingen) is afgeleid van NEN 3610 en wordt beheerd door Kadaster/KLIC.
+> IMKL is het sectormodel voor Kabels en Leidingen, beheerd door Kadaster/KLIC, afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMKL sectormodel
 
 <details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMKL.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst bevat geen informatie over IMKL, kabels en leidingen, of NEN 3610.*
+  - *De brontekst bevat geen informatie over IMKL, KLIC, kabels en leidingen, of NEN 3610.*
 </details>
 
-### `geo-model-0035` — reference.md:127 *(§ Domeinmodellen)*
+### `geo-model-0043` — reference.md:127 *(§ Domeinmodellen)*
 
-> IMBOR (Beheer Openbare Ruimte) is slechts gedeeltelijk afgeleid van NEN 3610 en wordt beheerd door CROW.
+> IMBOR (Beheer Openbare Ruimte, beheerd door CROW) is gedeeltelijk afgeleid van NEN 3610.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBOR, NEN 3610
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMBOR sectormodel
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over IMBOR.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0036` — reference.md:131 *(§ Relatie tussen Sectormodellen en NEN 3610)*
+### `geo-model-0044` — reference.md:131 *(§ Relatie tussen Sectormodellen en NEN 3610)*
 
-> Elk sectormodel breidt NEN 3610 uit door objecttypen te specialiseren via overerving van GeoObject, domein-specifieke attributen toe te voegen, waardelijsten te definiëren en domein-specifieke relaties te leggen.
+> Elk sectormodel breidt NEN 3610 uit door objecttypen te specialiseren (overerving van GeoObject), domein-specifieke attributen toe te voegen, domein-specifieke waardelijsten te definiëren, en domein-specifieke relaties te leggen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, sectormodellen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 sectormodellen
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over sectormodellen en overerving van GeoObject.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0037` — reference.md:142 *(§ NEN 3610 Ontologie)*
+### `geo-model-0045` — reference.md:143 *(§ NEN 3610 Ontologie)*
 
-> De NEN 3610 ontologie is beschikbaar als RDF/OWL en is gepubliceerd onder de namespace https://definities.geostandaarden.nl/nen3610-2022/nl/.
+> De NEN 3610 ontologie is beschikbaar als RDF/OWL met namespace https://definities.geostandaarden.nl/nen3610-2022/nl/.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, RDF/OWL
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 Linked Data ontologie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over de NEN 3610 RDF/OWL ontologie.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0038` — reference.md:151 *(§ NEN 3610 Ontologie)*
+### `geo-model-0046` — reference.md:151 *(§ NEN 3610 Ontologie)*
 
-> In de NEN 3610 ontologie is GeoObject een subklasse van geo:Feature (GeoSPARQL).
+> nen3610:GeoObject is een subklasse van geo:Feature (GeoSPARQL) in de NEN 3610 ontologie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, Linked Data, GeoSPARQL
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 Linked Data ontologie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over GeoSPARQL of geo:Feature.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0040` — reference.md:202 *(§ Enterprise Architect)*
+### `geo-model-0048` — reference.md:202 *(§ Enterprise Architect)*
 
-> Enterprise Architect (Sparx Systems) is de standaardtool voor het opstellen van MIM-conforme informatiemodellen; er is een MIM-profiel beschikbaar.
+> Enterprise Architect (Sparx Systems) is de standaardtool voor het opstellen van MIM-conforme informatiemodellen. Er is een MIM-profiel beschikbaar.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, tooling
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM tooling
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over Enterprise Architect of MIM-tooling.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0041` — reference.md:206 *(§ Imvertor)*
+### `geo-model-0049` — reference.md:206 *(§ Imvertor)*
 
-> Imvertor transformeert UML-modellen naar XSD (GML application schema), JSON Schema, RDF/SKOS/SHACL en HTML-documentatie.
+> Imvertor transformeert UML-modellen naar technische schema's: UML naar XSD, JSON Schema, RDF/SKOS/SHACL, en HTML-documentatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, Imvertor, tooling
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM tooling / Imvertor
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over Imvertor.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0042` — reference.md:214 *(§ ShapeChange)*
+### `geo-model-0050` — reference.md:214 *(§ ShapeChange)*
 
 > ShapeChange (interactive instruments) is een alternatieve tool voor het genereren van GML application schema's uit UML-modellen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, ShapeChange, tooling
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM tooling / ShapeChange
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over ShapeChange.*
-</details>
-
-### `geo-model-0049` — reference.md:67 *(§ Stereotypen)*
-
-> MIM onderscheidt stereotype <<codelijst>> als uitbreidbare waardelijst (dynamische waardelijsten) naast <<enumeratie>> als vaste waardelijst.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM, stereotypen
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over MIM-stereotypen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
 ## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (3)
@@ -498,252 +530,241 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
-  > ze kunnen als basis gebruikt worden voor (bij voorkeur model-driven generatie van) afgeleide modellen en producten voor een specifiek toepassingsgebied/domein zoals bijvoorbeeld [ NEN3610 ] of het gemeentelijke domein
-  - *De bron bevestigt dat NEN 3610 een normatieve referentie is en als voorbeeld van een domeinspecifiek toepassingsgebied wordt genoemd, maar omschrijft MIM als het basismodel — niet NEN 3610. Dat NEN 3610 het basismodel voor geo-informatie in Nederland is en dat IMBAG, IMRO etc. daarvan zijn afgeleid, staat niet in deze bron.*
+  > ze kunnen als basis gebruikt worden voor (bij voorkeur model-driven generatie van) afgeleide modellen en producten voor een specifiek toepassingsgebied/domein zoals bijvoorbeeld [NEN3610] of het gemeentelijke domein
+  - *De bron bevestigt dat NEN3610 een normreferentie is en dat informatiemodellen als basis kunnen dienen voor afgeleide modellen voor specifieke domeinen (met NEN3610 als voorbeeld). De claim dat NEN 3610 het basismodel is waarvan IMGeo, IMBAG, IMRO etc. zijn afgeleid, wordt niet expliciet in de bron bevestigd. NEN3610 wordt enkel als normreferentie en voorbeeld van een domeinmodel genoemd.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
-  - *De brontekst is uitsluitend een bestandsindex (directory listing). Er staat geen inhoud over NEN 3610 als basismodel of afgeleide sectorale modellen.*
+  - *De aangeleverde brontekst is uitsluitend een directory-index met bestandsnamen en datums; geen inhoudelijke tekst over het basismodel of afgeleide sectorale informatiemodellen.*
 
-### `geo-model-0004` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
+### `geo-model-0003` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
 
-> Geonovum beheert zowel NEN 3610 als MIM.
+> Het Metamodel Informatie Modellering (MIM) beschrijft hoe informatiemodellen opgesteld moeten worden. Geonovum beheert beide standaarden (NEN 3610 en MIM).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610, MIM
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM / NEN 3610 / Geonovum
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+- **PARTIALLY_SUPPORTED** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
   > Het beheer van dit metamodel vindt plaats door Geonovum met ondersteuning van het Kadaster.
-  - *De bron bevestigt dat Geonovum MIM beheert. Dat Geonovum ook NEN 3610 beheert staat niet in deze bron; NEN 3610 wordt alleen als normatieve referentie vermeld.*
+  - *De bron bevestigt dat Geonovum MIM beheert (met ondersteuning van het Kadaster). De beschrijving dat MIM voorschrijft hoe informatiemodellen opgesteld moeten worden is ook ondersteund. De claim dat Geonovum ook NEN 3610 beheert wordt niet in deze bron vermeld — NEN 3610 wordt alleen als normreferentie genoemd.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
-  - *De brontekst bevat geen informatie over Geonovum als beheerder van NEN 3610 of MIM.*
+  - *De aangeleverde brontekst is uitsluitend een directory-index; geen inhoud over MIM, beheer door Geonovum, of de relatie tussen NEN 3610 en MIM.*
 
-### `geo-model-0009` — SKILL.md:32 *(§ Standaarden Overzicht)*
+### `geo-model-0008` — SKILL.md:32 *(§ Standaarden Overzicht)*
 
-> IMRO heeft Forum Standaardisatie status 'Verplicht (als sectormodel)' en licentie CC-BY-ND-4.0.
+> IMRO heeft Forum Standaardisatie status 'Verplicht (als sectormodel)' en een CC-BY-ND-4.0 licentie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO, Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMRO / Forum Standaardisatie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/ro/imro](https://docs.geostandaarden.nl/ro/imro)
   > Dit document valt onder de volgende licentie: Creative Commons Naamsvermelding-GeenAfgeleideWerken 4.0 Internationaal
-  - *De licentie CC-BY-ND-4.0 wordt bevestigd door de metadata van het document. De Forum Standaardisatie-status 'Verplicht (als sectormodel)' wordt nergens in de brontekst vermeld.*
+  - *De CC-BY-ND-4.0 licentie wordt bevestigd door de bronvermelding bovenaan het document. De claim over Forum Standaardisatie status 'Verplicht (als sectormodel)' wordt niet in deze bron behandeld.*
 
-## UNGROUNDED — geen bron ondersteunt de claim (14)
+## UNGROUNDED — geen bron ondersteunt de claim (13)
 
-### `geo-model-0001` — SKILL.md:20 *(§ Informatiemodellen voor Geodata)*
+### `geo-model-0011` — SKILL.md:75 *(§ Verplichte Eigenschappen van GeoObject)*
 
-> NEN 3610 is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+> GeoObject heeft eigenschap 'identificatie' van type NEN3610ID met cardinaliteit verplicht.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, Forum Standaardisatie
-
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
-  - *De aangeleverde brontekst is een directory-index van docs.geostandaarden.nl/nen3610 en bevat geen inhoudelijke informatie over verplichtingstatus of Forum Standaardisatie.*
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
-  - *De brontekst behandelt MIM uitgebreid maar vermeldt nergens de 'pas-toe-of-leg-uit'-verplichting van het Forum Standaardisatie voor NEN 3610.*
-
-### `geo-model-0013` — SKILL.md:75 *(§ Verplichte Eigenschappen van GeoObject)*
-
-> GeoObject heeft de verplichte eigenschap 'identificatie' van type NEN3610ID (unieke identificatie bestaande uit namespace, lokaalId en versie).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 GeoObject
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst is een directory listing zonder inhoudelijke specificaties.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0014` — SKILL.md:77 *(§ Verplichte Eigenschappen van GeoObject)*
+### `geo-model-0012` — SKILL.md:77 *(§ Verplichte Eigenschappen van GeoObject)*
 
-> GeoObject heeft de verplichte eigenschap 'tijdstipRegistratie' van type DateTime.
+> GeoObject heeft eigenschap 'tijdstipRegistratie' van type DateTime.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 GeoObject
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0015` — SKILL.md:79 *(§ Verplichte Eigenschappen van GeoObject)*
+### `geo-model-0013` — SKILL.md:79 *(§ Verplichte Eigenschappen van GeoObject)*
 
-> GeoObject heeft de verplichte eigenschap 'beginGeldigheid' van type DateTime.
+> GeoObject heeft eigenschap 'beginGeldigheid' van type DateTime.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 GeoObject
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0016` — SKILL.md:81 *(§ Verplichte Eigenschappen van GeoObject)*
+### `geo-model-0014` — SKILL.md:81 *(§ Verplichte Eigenschappen van GeoObject)*
 
-> GeoObject heeft de verplichte eigenschap 'geometrie' van type GM_Object.
+> GeoObject heeft eigenschap 'geometrie' van type GM_Object.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 GeoObject
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over GeoObject-eigenschappen.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0019` — SKILL.md:211 *(§ Veelvoorkomende Problemen)*
+### `geo-model-0016` — SKILL.md:211 *(§ Veelvoorkomende Problemen)*
 
-> Voor geodata in Nederland moet EPSG:28992 als coördinatenreferentiestelsel worden gebruikt en gespecificeerd via srsName in GML.
+> Voor GML-geometrie in Nederland moet het coördinatenstelsel EPSG:28992 (RD New) gebruikt worden, gespecificeerd via het srsName-attribuut.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GML, geometrie
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NEN 3610 GML geometrie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over coördinatenreferentiestelsels of GML.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0026` — reference.md:77 *(§ Naamgevingsregels)*
+### `geo-model-0024` — SKILL.md:209 *(§ Veelvoorkomende Problemen)*
 
-> MIM schrijft voor dat Objecttype-namen UpperCamelCase enkelvoud zijn, attribuutsoort-namen lowerCamelCase, en relatiesoort-namen lowerCamelCase werkwoorden.
+> Voor een verkeerde namespace in GML moet de juiste namespace-URI voor het sectormodel gebruikt worden.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** MIM, naamgevingsregels
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 GML implementatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over MIM-naamgevingsregels.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0039` — reference.md:186 *(§ URI Dereferencing)*
+### `geo-model-0025` — SKILL.md:210 *(§ Veelvoorkomende Problemen)*
 
-> Voor een werkende linked data-implementatie van geo-objecten is content negotiation vereist met 303 See Other redirects.
+> NEN3610ID vereist een unieke combinatie van namespace en lokaalID.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, Linked Data, URI dereferencing
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 identificatie
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over content negotiation of 303-redirects.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0043` — reference.md:19 *(§ Basisklassen)*
+### `geo-model-0026` — SKILL.md:213 *(§ Veelvoorkomende Problemen)*
 
-> NEN 3610 GeoObject heeft attribuut 'geometrie' met cardinaliteit [1..*] (verplicht, 1 of meer).
+> Linked data URIs voor geo-objecten moeten dereferenceable zijn via content negotiation en 303 redirects.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 Linked Data
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0044` — reference.md:13 *(§ Basisklassen)*
+### `geo-model-0027` — SKILL.md:214 *(§ Veelvoorkomende Problemen)*
 
-> NEN 3610 GeoObject heeft attribuut 'identificatie' met cardinaliteit [1..1] (verplicht, precies 1).
+> Elk sectormodel moet afgeleid zijn van NEN 3610 als basis.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 sectormodellen
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0045` — reference.md:15 *(§ Basisklassen)*
+### `geo-model-0032` — reference.md:77 *(§ Naamgevingsregels)*
 
-> NEN 3610 GeoObject heeft attribuut 'tijdstipRegistratie' met cardinaliteit [1..1] (verplicht, precies 1).
+> MIM naamgevingsconventie: Objecttype gebruikt UpperCamelCase enkelvoud (bijv. Wegdeel, Waterdeel).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** MIM naamgevingsregels
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0046` — reference.md:17 *(§ Basisklassen)*
+### `geo-model-0033` — reference.md:78 *(§ Naamgevingsregels)*
 
-> NEN 3610 GeoObject heeft attribuut 'beginGeldigheid' met cardinaliteit [1..1] (verplicht, precies 1).
+> MIM naamgevingsconventie: Attribuutsoort gebruikt lowerCamelCase (bijv. bouwjaar, oppervlakte).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, GeoObject, UML
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** MIM naamgevingsregels
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen UML-cardinaliteiten voor GeoObject.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0047` — reference.md:22 *(§ Basisklassen)*
+### `geo-model-0034` — reference.md:79 *(§ Naamgevingsregels)*
 
-> NEN3610ID heeft namespace en lokaalID als verplichte velden ([1..1]) en versie als optioneel veld ([0..1]).
+> MIM naamgevingsconventie: Relatiesoort gebruikt lowerCamelCase als werkwoord (bijv. ligtIn, hoortBij).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, NEN3610ID, UML
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** MIM naamgevingsregels
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over NEN3610ID-cardinaliteiten.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
-### `geo-model-0048` — reference.md:40 *(§ Specialisaties van GeoObject (NEN 3610:2022))*
+### `geo-model-0047` — reference.md:186 *(§ URI Dereferencing)*
 
-> FunctioneleRuimte (specialisatie van VirtueleRuimte) heeft attribuut 'functie' met cardinaliteit [1..1] (verplicht).
+> Voor een werkende linked data-implementatie is content negotiation nodig, met 303 See Other redirects naar formaat-specifieke representaties.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610, VirtueleRuimte, UML
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 Linked Data URI dereferencing
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610/](https://docs.geostandaarden.nl/nen3610/)
-  - *Brontekst is alleen een directory listing, geen inhoudelijke specificatie.*
+  - *Brontekst bevat alleen een directory-listing, geen inhoudelijke specificaties.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/](https://docs.geostandaarden.nl/mim/)
-  - *Brontekst is alleen een bestandsindex zonder inhoudelijke specificatietekst.*
+  - *Brontekst is enkel een directory-listing, geen inhoudelijke specificatie.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/](https://docs.geostandaarden.nl/nl-sbb/)
-  - *Aangeleverde brontekst bevat geen informatie over FunctioneleRuimte of VirtueleRuimte.*
+  - *Brontekst is alleen een directory-listing, geen inhoudelijke specificatie.*
 </details>
 
 ## GROUNDED — minstens één bron ondersteunt de claim (1)
@@ -751,15 +772,23 @@
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `geo-model-0003` — SKILL.md:22 *(§ Informatiemodellen voor Geodata)*
+### `geo-model-0001` — SKILL.md:20 *(§ Informatiemodellen voor Geodata)*
 
-> Het Metamodel Informatie Modellering (MIM) beschrijft hoe informatiemodellen opgesteld moeten worden.
+> NEN 3610 is verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NEN 3610 / Forum Standaardisatie
 
-- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
-  > Met MIM, het Metamodel voor Informatie Modellering, wordt een metamodel beschreven waar informatiemodellen mee gemaakt kunnen worden. Het beschrijft de metaklassen, metastructuur en metagegevens als grondslag voor een informatiemodel. Doel hiervan is standaardiseren van de methode van informatiemodelleren
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > NEN 3610:2022 (nl) Basismodel Geo-informatie - Termen, definities, relaties en algemene regels voor de uitwisseling van informatie over aan de aarde gerelateerde ruimtelijke objecten, versie 2022 (specifiek toepassingsgebied : metadatering van geografische datasets en dataset series)
+  - *De bron bevestigt expliciet dat NEN 3610 onderdeel is van de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie. Op 1 februari 2024 stemde het OBDO in met het blijven verplichten van NEN 3610 aan de overheid in versie 2022.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (low) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst bevat alleen navigatie-elementen en categorienamen van de Forum Standaardisatie website, zonder een concrete lijst van standaarden. NEN 3610 wordt nergens genoemd. Het is onmogelijk te verifiëren of NEN 3610 specifiek op de 'pas toe of leg uit'-lijst staat op basis van deze tekst.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nen3610](https://docs.geostandaarden.nl/nen3610)
-  - *De brontekst bevat geen informatie over MIM of het Metamodel Informatie Modellering.*
+  - *De aangeleverde brontekst is uitsluitend een directory-index van docs.geostandaarden.nl/nen3610 zonder inhoudelijke informatie over Forum Standaardisatie of pas-toe-of-leg-uit status.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/mim/def-st-mim-20220217](https://docs.geostandaarden.nl/mim/def-st-mim-20220217)
+  - *De brontekst (MIM-specificatie) behandelt het Forum Standaardisatie en 'pas-toe-of-leg-uit' niet. Dit is een MIM-standaard document, niet een overzicht van Forum Standaardisatie verplichtingen.*
+</details>
 
 </details>

--- a/skills/geo/audit.md
+++ b/skills/geo/audit.md
@@ -1,0 +1,282 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit geo — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 3 | 13% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 9 | 39% |
+| UNGROUNDED | 0 | 0% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 11 | 48% |
+
+*Geverifieerd met sonnet, 15 calls, $1.0929.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (3)
+
+### `geo-0001` — SKILL.md:22 *(§ Geonovum Geo-standaarden - Overzicht)*
+
+> Geonovum is de Nederlandse organisatie die geo-standaarden ontwikkelt en beheert.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum organisatie
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst betreft de website van Forum Standaardisatie (forumstandaardisatie.nl) en bevat geen informatie over Geonovum of haar rol als beheerder van geo-standaarden.*
+
+### `geo-0002` — SKILL.md:22 *(§ Geonovum Geo-standaarden - Overzicht)*
+
+> De geo-standaarden zijn gepubliceerd op docs.geostandaarden.nl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum geo-standaarden publicatie
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst bevat geen verwijzing naar docs.geostandaarden.nl of de publicatielocatie van geo-standaarden.*
+
+### `geo-0023` — SKILL.md:85 *(§ Aanvullende Standaarden)*
+
+> IMX-Geo is een semantisch model voor samenhang tussen basis- en kernregistraties, ontwikkeld door Kadaster en Geonovum.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMX-Geo standaard
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *IMX-Geo, semantische modellen of een samenwerking met Geonovum worden in de brontekst niet vermeld.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
+  - *IMX-Geo wordt nergens in de brontekst genoemd. De bron vermeldt wel Kadaster en Geonovum als organisaties, maar niet in relatie tot een IMX-Geo semantisch model voor samenhang tussen basis- en kernregistraties.*
+- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
+  - *IMX-Geo wordt nergens in deze brontekst genoemd. De bron gaat uitsluitend over NL-SBB. Kadaster wordt wel als organisatie van auteurs vermeld (Jesse Bakker, Arjen Santema), maar IMX-Geo als semantisch model voor basis- en kernregistraties wordt niet behandeld.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (9)
+
+### `geo-0012` — SKILL.md:60 *(§ Sleutelorganisaties)*
+
+> PDOK (Publieke Dienstverlening Op de Kaart) is het nationale geo-dataportaal en host geo-services.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** PDOK organisatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  > Open geodata portaal Open overheidsdata [...] Iedereen mag kosteloos data afnemen bij PDOK. [...] Via PDOK kunnen diverse datasets worden "gedownload". [...] Uitleg over de belangrijkste OGC standaarden die in gebruik zijn bij PDOK staat op https://www.pdok.nl/services-en-api-s
+  - *De bron bevestigt dat PDOK een open geodataportaal is dat geo-services en datasets aanbiedt. De uitbreiding 'Publieke Dienstverlening Op de Kaart' en de kwalificatie 'nationaal' worden niet expliciet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/](https://docs.geostandaarden.nl/)
+  - *De brontekst is een inhoudsopgave van Geonovum-documentatie en bevat geen informatie over PDOK of haar rol als nationaal geo-dataportaal.*
+- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden](https://www.geonovum.nl/geo-standaarden)
+  - *De brontekst gaat over geo-standaarden die Geonovum beheert. PDOK wordt nergens in de tekst genoemd.*
+
+### `geo-0013` — SKILL.md:61 *(§ Sleutelorganisaties)*
+
+> Het Kadaster beheert de basisregistraties BAG en BRK, beheert PDOK, en de Landelijke Voorziening BGT.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Kadaster organisatie
+
+- **PARTIALLY_SUPPORTED** (low) — [https://www.geonovum.nl/geo-standaarden](https://www.geonovum.nl/geo-standaarden)
+  > "In de verschillende registraties die de overheid beheert, is veel praktische basisinformatie te vinden. [...] werken Kadaster en Geonovum samen aan een semantisch samenhangend model." en "Het ministerie van VRO, Kadaster en Geonovum, werken vanuit het programma Zicht op Nederland Datafundament (ZoN DF) aan een Informatiemodel Bestuurlijke Gebieden"
+  - *De bron noemt Kadaster als samenwerkingspartner bij IMX-Geo en Informatiemodel Bestuurlijke Gebieden, maar vermeldt niets over BAG, BRK, PDOK-beheer, of de Landelijke Voorziening BGT. Het grootste deel van de claim is niet te verifiëren op basis van deze bron.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/](https://docs.geostandaarden.nl/)
+  - *De brontekst bevat geen informatie over het Kadaster, BAG, BRK, PDOK-beheer of de Landelijke Voorziening BGT.*
+- **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  - *De brontekst vermeldt het Kadaster alleen in de context van de Kadastrale kaart en oppervlakteberekeningen. Er staat niets over BAG, BRK, beheer van PDOK door het Kadaster, of de Landelijke Voorziening BGT.*
+- **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
+  - *De brontekst is de homepage van developer.kadaster.nl en noemt geen specifieke basisregistraties (BAG, BRK), PDOK-beheer of Landelijke Voorziening BGT. Alleen een algemene verwijzing naar 'datasets' en 'PDOK.nl' staat in de tekst.*
+</details>
+
+### `geo-0015` — SKILL.md:70 *(§ Belangrijke Repositories)*
+
+> De Geonovum/NEN3610-Linkeddata repository bevat het NEN 3610 linked data profiel en heeft de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN3610-Linkeddata repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata)
+  > Repository voor het werken aan een linked data profiel op NEN3610. Dit profiel wordt beschreven in een document.
+  - *De bron bevestigt dat de repository het NEN3610 linked data profiel bevat. Er is echter geen vermelding van de CC-BY-4.0 licentie in de aangeleverde brontekst.*
+
+### `geo-0016` — SKILL.md:71 *(§ Belangrijke Repositories)*
+
+> De Geonovum/Metadata-ISO19115 repository bevat het Nederlands profiel ISO 19115 metadata en heeft de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Metadata-ISO19115 repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115)
+  > Werkversie Nederlands profiel op ISO 19115 voor geografie versie 2.X.X
+  - *De bron bevestigt dat de repository het Nederlands profiel op ISO 19115 bevat. De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
+
+### `geo-0017` — SKILL.md:72 *(§ Belangrijke Repositories)*
+
+> De Geonovum/inspire-handreiking repository bevat de INSPIRE implementatie handreiking en heeft de CC-BY-ND-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** inspire-handreiking repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking)
+  > INSPIRE-handreiking Welkom op de INSPIRE-handreiking. De werkversie van de handreiking kan benaderd worden via: https://geonovum.github.io/inspire-handreiking/
+  - *De bron bevestigt dat de repository de INSPIRE implementatie handreiking bevat. De licentie (CC-BY-ND-4.0) wordt nergens in de aangeleverde brontekst vermeld.*
+
+### `geo-0018` — SKILL.md:73 *(§ Belangrijke Repositories)*
+
+> De Geonovum/IMGeo repository bevat het Informatiemodel Geografie (BGT/IMGeo) en heeft de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/IMGeo](https://github.com/Geonovum/IMGeo)
+  > Geonovum / IMGeo Public ... About IMGeo volgens mappenstructuur op register.geostandaarden.nl
+  - *De bron bevestigt dat het een IMGeo repository van Geonovum betreft met mappen zoals 'informatiemodel', 'praktijkrichtlijn', etc., wat overeenkomt met het Informatiemodel Geografie (BGT/IMGeo). De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
+
+### `geo-0019` — SKILL.md:74 *(§ Belangrijke Repositories)*
+
+> De Geonovum/MIM-Werkomgeving repository bevat het Metamodel Informatie Modellering en heeft de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM-Werkomgeving repository
+
+- **PARTIALLY_SUPPORTED** (high) — [https://github.com/Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving)
+  > Dit is de repository van het Metamodel Informatie Modellering (MIM). Hierin staat de werkversie van het MIM.
+  - *De bron bevestigt dat de repository het Metamodel Informatie Modellering bevat. De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
+
+### `geo-0020` — SKILL.md:83 *(§ Aanvullende Standaarden)*
+
+> GeoPackage is een verplicht formaat voor geodata-downloads bij de overheid sinds 2019.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** GeoPackage standaard overheid
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+  > In 2019 is deze standaard opgenomen op de Nederlandse Pas-toe-of-leg-uit-lijst. Dit betekent dat Nederlandse overheidsorganisaties bij het aanbieden van een download van hun data naast GML ook het GeoPackage formaat moeten kunnen leveren.
+  - *De bron bevestigt dat GeoPackage verplicht is sinds 2019, maar het is geen vervanging van GML: overheidsorganisaties moeten GeoPackage naast GML aanbieden, niet in plaats daarvan. 'Verplicht formaat' dekt de lading dus niet volledig; het is een aanvullende verplichting.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
+  - *De bron vermeldt GeoPackage als uitwisselformaat-standaard (tabel 6.1) maar er staat nergens dat het een verplicht formaat is voor geodata-downloads bij de overheid, noch een datum van 2019. GeoPackage staat niet op de 'pas toe of leg uit' lijst volgens de brontekst.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
+  - *De brontekst gaat volledig over NL-SBB (standaard voor het beschrijven van begrippen). GeoPackage, geodata-downloads of verplichte formaten worden nergens genoemd.*
+
+### `geo-0021` — SKILL.md:82 *(§ Aanvullende Standaarden)*
+
+> Het Raamwerk Geo-Standaarden is een overzichtsdocument dat beschrijft hoe alle geo-standaarden samenhangen, gepubliceerd op docs.geostandaarden.nl/rwgs/rw/.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Raamwerk Geo-Standaarden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
+  > Het Raamwerk van geostandaarden is richtinggevend voor het gebruik van standaarden binnen de Nederlandse geo-informatie infrastructuur. [...] Het benoemt de internationale en nationale standaarden die voor Nederland binnen het geo-domein van toepassing zijn voor aansluiting met andere domeinen.
+  - *De bron bevestigt dat het Raamwerk een overzichtsdocument is dat samenhang van geostandaarden beschrijft. De URL docs.geostandaarden.nl/rwgs/rw/ is vermeld als 'Laatst gepubliceerde versie' in de header. De omschrijving 'hoe alle geo-standaarden samenhangen' is een juiste parafrase. Volledig ondersteund op inhoud, URL alleen impliciet aanwezig als metadata van het document zelf.*
+- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
+  - *Het Raamwerk Geo-Standaarden wordt niet genoemd in deze brontekst. De bron gaat uitsluitend over NL-SBB.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (11)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `geo-0003` — SKILL.md:26 *(§ Forum Standaardisatie Status)*
+
+> De geo-standaarden staan op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > De Geo-standaarden op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie bestaan thans uit: Nederlands metadataprofiel op ISO 19115 voor geografie, versie 2.1.0 [...] NEN 3610:2022 [...] ISO 19136:2007 [...] GeoPackage 1.3.1 [...] OGC-API – Features Part 1 [...] OGC-API – Tiles - Part 1: Core
+
+### `geo-0004` — SKILL.md:26 *(§ Forum Standaardisatie Status)*
+
+> Sinds september 2024 is de samenstelling van de geo-standaarden op de pas-toe-of-leg-uit-lijst gewijzigd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Op 19 september 2024 stemde het OBDO in met het verplichten van OGC-API – Features Part 1: Core en Part 2: Coordinate Reference Systems by Reference en OGC-API – Tiles - Part 1: Core door plaatsing op de 'pas toe of leg uit'-lijst en het aanbevelen van Nederlands WFS profiel 1.1 [...] en Nederlands profiel op ISO 19128 [...] (WMS) door plaatsing op de lijst aanbevolen standaarden.
+
+### `geo-0005` — SKILL.md:32 *(§ Forum Standaardisatie Status)*
+
+> GML is verplicht (pas-toe-of-leg-uit) als data-encoding standaard onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > ISO 19136:2007 Geographic information - Geography Markup Language (GML), versie 2007 (geen specifiek toepassingsgebied)
+  - *GML (ISO 19136:2007) staat expliciet op de 'pas toe of leg uit'-lijst. Dat er geen specifiek toepassingsgebied wordt vermeld is opvallend, maar de opname op de lijst is duidelijk.*
+
+### `geo-0006` — SKILL.md:33 *(§ Forum Standaardisatie Status)*
+
+> OGC API Features is verplicht (pas-toe-of-leg-uit) als REST API service onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > OGC-API – Features Part 1: Core en Part 2: Coordinate Reference Systems by Reference (specifiek toepassingsgebied: OGC-API - Features Part 1 en Part 2 moeten worden toegepast bij het per REST API aanbieden voor derden van geografische object-informatie)
+
+### `geo-0007` — SKILL.md:34 *(§ Forum Standaardisatie Status)*
+
+> OGC API Tiles is verplicht (pas-toe-of-leg-uit) als tileservice onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > OGC-API – Tiles - Part 1: Core (specifiek toepassingsgebied : OGC-API – OGC-API – Tiles Part 1 moet worden toegepast bij het per REST API aanbieden voor derden van geografische informatie als verbeelding)
+
+### `geo-0008` — SKILL.md:35 *(§ Forum Standaardisatie Status)*
+
+> NEN 3610 is verplicht (pas-toe-of-leg-uit) als informatiemodel onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > NEN 3610:2022 (nl) Basismodel Geo-informatie - Termen, definities, relaties en algemene regels voor de uitwisseling van informatie over aan de aarde gerelateerde ruimtelijke objecten, versie 2022 (specifiek toepassingsgebied : metadatering van geografische datasets en dataset series)
+
+### `geo-0009` — SKILL.md:36 *(§ Forum Standaardisatie Status)*
+
+> ISO 19115/19119 is verplicht (pas-toe-of-leg-uit) als metadata standaard onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Nederlands metadataprofiel op ISO 19115 voor geografie, versie 2.1.0 (specifiek toepassingsgebied : metadatering van geografische datasets en dataset series) Nederlands metadata profiel op ISO 19119 voor services, versie 2.1.0 (specifiek toepassingsgebied : metadatering van geografische informatie services)
+
+### `geo-0010` — SKILL.md:38 *(§ Forum Standaardisatie Status)*
+
+> WMS is sinds september 2024 verplaatst van verplicht naar aanbevolen als viewservice.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status WMS
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Op 19 september 2024 stemde het OBDO in met [...] het aanbevelen van [...] Nederlands profiel op ISO 19128 Geographic information - Web Map Server Interface (WMS) door plaatsing op de lijst aanbevolen standaarden.
+  - *De bron bevestigt dat WMS naar 'aanbevolen' is gegaan per september 2024. Dat het eerder verplicht was staat niet expliciet in deze tekst, maar de verplaatsing naar aanbevolen is duidelijk.*
+
+### `geo-0011` — SKILL.md:38 *(§ Forum Standaardisatie Status)*
+
+> WFS is sinds september 2024 verplaatst van verplicht naar aanbevolen als downloadservice.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status WFS
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > Op 19 september 2024 stemde het OBDO in met [...] het aanbevelen van Nederlands WFS profiel 1.1 op ISO 19142 voor Web Feature Services 2.0, versie 1.1 (WFS) [...] door plaatsing op de lijst aanbevolen standaarden.
+  - *De bron bevestigt dat WFS naar 'aanbevolen' is gegaan per september 2024. Dat het eerder verplicht was staat niet expliciet in deze tekst, maar de verplaatsing naar aanbevolen is duidelijk.*
+
+### `geo-0014` — SKILL.md:69 *(§ Belangrijke Repositories)*
+
+> De Geonovum/ogc-checker repository is een validatietool voor OGC services en heeft de EUPL-1.2 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker repository
+
+- **SUPPORTED** (high) — [https://github.com/Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker)
+  > Validates JSON-FG documents and OGC API endpoints against OGC specifications. [...] License EUPL-1.2
+
+### `geo-0022` — SKILL.md:84 *(§ Aanvullende Standaarden)*
+
+> NL-SBB is een standaard voor het beschrijven van begrippen, gepubliceerd op docs.geostandaarden.nl/nl-sbb/nl-sbb/.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL-SBB standaard
+
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
+  > Standaard voor het Beschrijven van Begrippen [ SBB ] [...] URL: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/
+  - *De bron vermeldt SBB (Standaard voor het Beschrijven van Begrippen) meerdere malen en geeft exact de URL docs.geostandaarden.nl/nl-sbb/nl-sbb/ in de referenties. De claim gebruikt de naam 'NL-SBB' terwijl de bron 'SBB' of 'NL-SBB' gebruikt; dit is dezelfde standaard.*
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
+  > NL-SBB - Standaard voor het beschrijven van begrippen Geonovum Standaard Vastgestelde versie 10 oktober 2024 [...] Deze versie: https://docs.geostandaarden.nl/nl-sbb/def-st-nl-sbb-20241010 Laatst gepubliceerde versie: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/
+  - *De bron bevestigt expliciet dat NL-SBB een standaard is voor het beschrijven van begrippen, gepubliceerd op docs.geostandaarden.nl/nl-sbb/nl-sbb/.*
+- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+
+</details>

--- a/skills/geo/audit.md
+++ b/skills/geo/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit geo — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,16 +7,16 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 3 | 13% |
+| UNSUPPORTED_ASSERTION | 3 | 14% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 9 | 39% |
+| PARTIALLY_GROUNDED | 8 | 36% |
 | UNGROUNDED | 0 | 0% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 11 | 48% |
+| GROUNDED | 11 | 50% |
 
-*Geverifieerd met sonnet, 15 calls, $1.0929.*
+*Geverifieerd met sonnet, 16 calls, $1.1593.*
 
 ## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (3)
 
@@ -27,7 +27,7 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum organisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *De brontekst betreft de website van Forum Standaardisatie (forumstandaardisatie.nl) en bevat geen informatie over Geonovum of haar rol als beheerder van geo-standaarden.*
+  - *De brontekst betreft de website van Forum Standaardisatie en bevat geen informatie over Geonovum als organisatie of haar rol bij het ontwikkelen van geo-standaarden.*
 
 ### `geo-0002` — SKILL.md:22 *(§ Geonovum Geo-standaarden - Overzicht)*
 
@@ -36,9 +36,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum geo-standaarden publicatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *De brontekst bevat geen verwijzing naar docs.geostandaarden.nl of de publicatielocatie van geo-standaarden.*
+  - *De brontekst bevat geen vermelding van docs.geostandaarden.nl of de publicatielocatie van geo-standaarden.*
 
-### `geo-0023` — SKILL.md:85 *(§ Aanvullende Standaarden)*
+### `geo-0015` — SKILL.md:85 *(§ Aanvullende Standaarden)*
 
 > IMX-Geo is een semantisch model voor samenhang tussen basis- en kernregistraties, ontwikkeld door Kadaster en Geonovum.
 
@@ -47,15 +47,26 @@
 <details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *IMX-Geo, semantische modellen of een samenwerking met Geonovum worden in de brontekst niet vermeld.*
+  - *IMX-Geo, semantisch model, samenhang tussen registraties, en Geonovum worden nergens in de brontekst genoemd.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
-  - *IMX-Geo wordt nergens in de brontekst genoemd. De bron vermeldt wel Kadaster en Geonovum als organisaties, maar niet in relatie tot een IMX-Geo semantisch model voor samenhang tussen basis- en kernregistraties.*
+  - *IMX-Geo wordt in de brontekst niet genoemd. De bron behandelt NEN 3610, MIM, sectorale informatiemodellen en basisregistraties, maar IMX-Geo als semantisch model voor samenhang tussen basis- en kernregistraties komt niet voor.*
 - **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+  - *De brontekst gaat uitsluitend over GeoPackage. IMX-Geo wordt nergens genoemd.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
-  - *IMX-Geo wordt nergens in deze brontekst genoemd. De bron gaat uitsluitend over NL-SBB. Kadaster wordt wel als organisatie van auteurs vermeld (Jesse Bakker, Arjen Santema), maar IMX-Geo als semantisch model voor basis- en kernregistraties wordt niet behandeld.*
+  - *De bron gaat over NL-SBB en bevat geen informatie over IMX-Geo, Kadaster als ontwikkelaar van een semantisch model voor basis- en kernregistraties in die context.*
 </details>
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (9)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (8)
+
+### `geo-0005` — SKILL.md:32 *(§ Forum Standaardisatie Status)*
+
+> GML is verplicht (pas-toe-of-leg-uit) als data-encoding standaard onderdeel van het Geo-Standaarden-pakket.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
+  > ISO 19136:2007 Geographic information - Geography Markup Language (GML), versie 2007 (geen specifiek toepassingsgebied)
+  - *GML staat inderdaad op de pas-toe-of-leg-uit-lijst, maar de bron vermeldt expliciet 'geen specifiek toepassingsgebied' — de omschrijving 'data-encoding standaard' staat niet in de bron. Bovendien noemt de bron dat 'uitstekend beheer' niet van toepassing is op GML, wat de claim niet tegenspreekt maar wel nuanceert.*
 
 ### `geo-0012` — SKILL.md:60 *(§ Sleutelorganisaties)*
 
@@ -64,108 +75,99 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** PDOK organisatie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
-  > Open geodata portaal Open overheidsdata [...] Iedereen mag kosteloos data afnemen bij PDOK. [...] Via PDOK kunnen diverse datasets worden "gedownload". [...] Uitleg over de belangrijkste OGC standaarden die in gebruik zijn bij PDOK staat op https://www.pdok.nl/services-en-api-s
-  - *De bron bevestigt dat PDOK een open geodataportaal is dat geo-services en datasets aanbiedt. De uitbreiding 'Publieke Dienstverlening Op de Kaart' en de kwalificatie 'nationaal' worden niet expliciet vermeld in de brontekst.*
+  > PDOK Promotiefilm met Nederlandstalige en Engelstalige ondertiteling (via instellingen) [...] Iedereen mag kosteloos data afnemen bij PDOK. [...] Via PDOK kunnen diverse datasets worden "gedownload". [...] Uitleg over de belangrijkste OGC standaarden die in gebruik zijn bij PDOK staat op https://www.pdok.nl/services-en-api-s
+  - *De bron bevestigt dat PDOK een geo-dataportaal is dat open geodata en geo-services aanbiedt. De volledige naam 'Publieke Dienstverlening Op de Kaart' wordt echter niet uitgeschreven in de brontekst, en de kwalificatie 'nationaal' wordt niet expliciet gebruikt.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/](https://docs.geostandaarden.nl/)
-  - *De brontekst is een inhoudsopgave van Geonovum-documentatie en bevat geen informatie over PDOK of haar rol als nationaal geo-dataportaal.*
+  - *De brontekst is een inhoudsopgave van Geonovum-documentatie op docs.geostandaarden.nl. PDOK wordt nergens vermeld in de aangeleverde tekst.*
 - **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden](https://www.geonovum.nl/geo-standaarden)
   - *De brontekst gaat over geo-standaarden die Geonovum beheert. PDOK wordt nergens in de tekst genoemd.*
 
 ### `geo-0013` — SKILL.md:61 *(§ Sleutelorganisaties)*
 
-> Het Kadaster beheert de basisregistraties BAG en BRK, beheert PDOK, en de Landelijke Voorziening BGT.
+> Het Kadaster beheert basisregistraties (BAG, BRK), PDOK en de Landelijke Voorziening BGT.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Kadaster organisatie
 
+- **PARTIALLY_SUPPORTED** (low) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
+  > Het Kadaster bepaalt niet een exacte maar een indicatieve grootte. Grootte is alleen authentiek als soort grootte de waarde "vastgesteld" heeft. [...] Deze informatie is te vinden in de modeldocumentatie van de Kadastrale kaart
+  - *De bron noemt het Kadaster alleen in de context van oppervlaktegegevens bij de Kadastrale kaart. Dat het Kadaster basisregistraties (BAG, BRK) beheert, PDOK beheert, of de Landelijke Voorziening BGT beheert, staat niet in de brontekst. Deze specifieke beheerstaken worden niet vermeld.*
 - **PARTIALLY_SUPPORTED** (low) — [https://www.geonovum.nl/geo-standaarden](https://www.geonovum.nl/geo-standaarden)
-  > "In de verschillende registraties die de overheid beheert, is veel praktische basisinformatie te vinden. [...] werken Kadaster en Geonovum samen aan een semantisch samenhangend model." en "Het ministerie van VRO, Kadaster en Geonovum, werken vanuit het programma Zicht op Nederland Datafundament (ZoN DF) aan een Informatiemodel Bestuurlijke Gebieden"
-  - *De bron noemt Kadaster als samenwerkingspartner bij IMX-Geo en Informatiemodel Bestuurlijke Gebieden, maar vermeldt niets over BAG, BRK, PDOK-beheer, of de Landelijke Voorziening BGT. Het grootste deel van de claim is niet te verifiëren op basis van deze bron.*
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
+  > IMX-Geo | Semantisch model basis- en kernregistraties: 'Om hergebruik van gegevens uit de kernregistraties eenvoudiger te maken, werken Kadaster en Geonovum samen aan een semantisch samenhangend model.'
+  - *De bron bevestigt dat Kadaster samenwerkt met Geonovum, maar noemt BAG, BRK, PDOK of Landelijke Voorziening BGT niet expliciet als producten die Kadaster beheert. De claim over specifieke basisregistraties en PDOK is niet terug te vinden in deze brontekst.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/](https://docs.geostandaarden.nl/)
-  - *De brontekst bevat geen informatie over het Kadaster, BAG, BRK, PDOK-beheer of de Landelijke Voorziening BGT.*
-- **NOT_FOUND** (high) — [https://www.pdok.nl/how-to-faq](https://www.pdok.nl/how-to-faq)
-  - *De brontekst vermeldt het Kadaster alleen in de context van de Kadastrale kaart en oppervlakteberekeningen. Er staat niets over BAG, BRK, beheer van PDOK door het Kadaster, of de Landelijke Voorziening BGT.*
+  - *Het Kadaster, BAG, BRK, PDOK en de Landelijke Voorziening BGT worden geen van allen vermeld in de aangeleverde brontekst.*
 - **NOT_FOUND** (high) — [https://developer.kadaster.nl/](https://developer.kadaster.nl/)
-  - *De brontekst is de homepage van developer.kadaster.nl en noemt geen specifieke basisregistraties (BAG, BRK), PDOK-beheer of Landelijke Voorziening BGT. Alleen een algemene verwijzing naar 'datasets' en 'PDOK.nl' staat in de tekst.*
-</details>
+  - *De brontekst is een algemene developer-landingspagina van Kadaster. Er staat geen specifieke vermelding van BAG, BRK, BGT of PDOK als basisregistraties beheerd door Kadaster. PDOK wordt wel als naam genoemd maar niet in de context van beheer.*
 
-### `geo-0015` — SKILL.md:70 *(§ Belangrijke Repositories)*
+### `geo-0014` — SKILL.md:83 *(§ Aanvullende Standaarden)*
 
-> De Geonovum/NEN3610-Linkeddata repository bevat het NEN 3610 linked data profiel en heeft de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN3610-Linkeddata repository
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata)
-  > Repository voor het werken aan een linked data profiel op NEN3610. Dit profiel wordt beschreven in een document.
-  - *De bron bevestigt dat de repository het NEN3610 linked data profiel bevat. Er is echter geen vermelding van de CC-BY-4.0 licentie in de aangeleverde brontekst.*
-
-### `geo-0016` — SKILL.md:71 *(§ Belangrijke Repositories)*
-
-> De Geonovum/Metadata-ISO19115 repository bevat het Nederlands profiel ISO 19115 metadata en heeft de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Metadata-ISO19115 repository
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/Metadata-ISO19115](https://github.com/Geonovum/Metadata-ISO19115)
-  > Werkversie Nederlands profiel op ISO 19115 voor geografie versie 2.X.X
-  - *De bron bevestigt dat de repository het Nederlands profiel op ISO 19115 bevat. De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
-
-### `geo-0017` — SKILL.md:72 *(§ Belangrijke Repositories)*
-
-> De Geonovum/inspire-handreiking repository bevat de INSPIRE implementatie handreiking en heeft de CC-BY-ND-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** inspire-handreiking repository
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking)
-  > INSPIRE-handreiking Welkom op de INSPIRE-handreiking. De werkversie van de handreiking kan benaderd worden via: https://geonovum.github.io/inspire-handreiking/
-  - *De bron bevestigt dat de repository de INSPIRE implementatie handreiking bevat. De licentie (CC-BY-ND-4.0) wordt nergens in de aangeleverde brontekst vermeld.*
-
-### `geo-0018` — SKILL.md:73 *(§ Belangrijke Repositories)*
-
-> De Geonovum/IMGeo repository bevat het Informatiemodel Geografie (BGT/IMGeo) en heeft de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo repository
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/IMGeo](https://github.com/Geonovum/IMGeo)
-  > Geonovum / IMGeo Public ... About IMGeo volgens mappenstructuur op register.geostandaarden.nl
-  - *De bron bevestigt dat het een IMGeo repository van Geonovum betreft met mappen zoals 'informatiemodel', 'praktijkrichtlijn', etc., wat overeenkomt met het Informatiemodel Geografie (BGT/IMGeo). De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
-
-### `geo-0019` — SKILL.md:74 *(§ Belangrijke Repositories)*
-
-> De Geonovum/MIM-Werkomgeving repository bevat het Metamodel Informatie Modellering en heeft de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM-Werkomgeving repository
-
-- **PARTIALLY_SUPPORTED** (high) — [https://github.com/Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving)
-  > Dit is de repository van het Metamodel Informatie Modellering (MIM). Hierin staat de werkversie van het MIM.
-  - *De bron bevestigt dat de repository het Metamodel Informatie Modellering bevat. De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld.*
-
-### `geo-0020` — SKILL.md:83 *(§ Aanvullende Standaarden)*
-
-> GeoPackage is een verplicht formaat voor geodata-downloads bij de overheid sinds 2019.
+> GeoPackage is verplicht formaat voor geodata-downloads bij de overheid sinds 2019.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** GeoPackage standaard overheid
 
 - **PARTIALLY_SUPPORTED** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
   > In 2019 is deze standaard opgenomen op de Nederlandse Pas-toe-of-leg-uit-lijst. Dit betekent dat Nederlandse overheidsorganisaties bij het aanbieden van een download van hun data naast GML ook het GeoPackage formaat moeten kunnen leveren.
-  - *De bron bevestigt dat GeoPackage verplicht is sinds 2019, maar het is geen vervanging van GML: overheidsorganisaties moeten GeoPackage naast GML aanbieden, niet in plaats daarvan. 'Verplicht formaat' dekt de lading dus niet volledig; het is een aanvullende verplichting.*
+  - *De bron bevestigt de opname in 2019 en de verplichting voor overheidsorganisaties, maar nuanceert dat GeoPackage naast GML geleverd moet worden, niet als enig verplicht formaat. De claim 'verplicht formaat' is daarmee niet volledig juist: het is een aanvullende verplichting naast GML.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
-  - *De bron vermeldt GeoPackage als uitwisselformaat-standaard (tabel 6.1) maar er staat nergens dat het een verplicht formaat is voor geodata-downloads bij de overheid, noch een datum van 2019. GeoPackage staat niet op de 'pas toe of leg uit' lijst volgens de brontekst.*
+  - *De bron vermeldt GeoPackage als uitwisselstandaard (tabel 6.1) en als INSPIRE good practice, maar er staat nergens dat het een verplicht formaat is voor geodata-downloads bij de overheid 'sinds 2019'. Er is geen verplichting of datum vermeld.*
 - **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
-  - *De brontekst gaat volledig over NL-SBB (standaard voor het beschrijven van begrippen). GeoPackage, geodata-downloads of verplichte formaten worden nergens genoemd.*
+  - *De bron gaat over NL-SBB (standaard voor het beschrijven van begrippen) en bevat geen informatie over GeoPackage of verplichte formaten voor geodata-downloads.*
 
-### `geo-0021` — SKILL.md:82 *(§ Aanvullende Standaarden)*
+### `geo-0019` — SKILL.md:70 *(§ Belangrijke Repositories)*
 
-> Het Raamwerk Geo-Standaarden is een overzichtsdocument dat beschrijft hoe alle geo-standaarden samenhangen, gepubliceerd op docs.geostandaarden.nl/rwgs/rw/.
+> Geonovum/NEN3610-Linkeddata bevat het NEN 3610 linked data profiel en is uitgebracht onder CC-BY-4.0 licentie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Raamwerk Geo-Standaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NEN 3610 linked data repository
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
-  > Het Raamwerk van geostandaarden is richtinggevend voor het gebruik van standaarden binnen de Nederlandse geo-informatie infrastructuur. [...] Het benoemt de internationale en nationale standaarden die voor Nederland binnen het geo-domein van toepassing zijn voor aansluiting met andere domeinen.
-  - *De bron bevestigt dat het Raamwerk een overzichtsdocument is dat samenhang van geostandaarden beschrijft. De URL docs.geostandaarden.nl/rwgs/rw/ is vermeld als 'Laatst gepubliceerde versie' in de header. De omschrijving 'hoe alle geo-standaarden samenhangen' is een juiste parafrase. Volledig ondersteund op inhoud, URL alleen impliciet aanwezig als metadata van het document zelf.*
-- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
-- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
-  - *Het Raamwerk Geo-Standaarden wordt niet genoemd in deze brontekst. De bron gaat uitsluitend over NL-SBB.*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/NEN3610-Linkeddata/main/LICENSE](https://raw.githubusercontent.com/Geonovum/NEN3610-Linkeddata/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/NEN3610-Linkeddata/master/LICENSE](https://raw.githubusercontent.com/Geonovum/NEN3610-Linkeddata/master/LICENSE)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/NEN3610-Linkeddata](https://github.com/Geonovum/NEN3610-Linkeddata)
+  > Repository voor het werken aan een linked data profiel op NEN3610. De concepttekst is hier te lezen: https://geonovum.github.io/NEN3610-Linkeddata
+  - *De bron bevestigt dat de repository het NEN 3610 linked data profiel bevat, maar vermeldt nergens een CC-BY-4.0 licentie. Er is geen licentie-informatie aanwezig in de aangeleverde brontekst.*
+
+### `geo-0020` — SKILL.md:72 *(§ Belangrijke Repositories)*
+
+> Geonovum/inspire-handreiking bevat de INSPIRE implementatie handreiking en is uitgebracht onder CC-BY-ND-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** INSPIRE handreiking repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/inspire-handreiking/main/LICENSE](https://raw.githubusercontent.com/Geonovum/inspire-handreiking/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/inspire-handreiking/master/LICENSE](https://raw.githubusercontent.com/Geonovum/inspire-handreiking/master/LICENSE)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/inspire-handreiking](https://github.com/Geonovum/inspire-handreiking)
+  > INSPIRE-handreiking Welkom op de INSPIRE-handreiking. De werkversie van de handreiking kan benaderd worden via: https://geonovum.github.io/inspire-handreiking/ De laatste officiele publicatie kan benaderd worden via: https://docs.geostandaarden.nl/eu/INSPIRE-handreiking/
+  - *De bron bevestigt dat de repository de INSPIRE implementatie handreiking bevat. De CC-BY-ND-4.0 licentie wordt echter nergens in de aangeleverde brontekst vermeld — er is geen LICENSE-bestand of licentie-aanduiding zichtbaar in de weergegeven inhoud.*
+
+### `geo-0021` — SKILL.md:73 *(§ Belangrijke Repositories)*
+
+> Geonovum/IMGeo bevat het Informatiemodel Geografie (BGT/IMGeo) en is uitgebracht onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IMGeo repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/IMGeo/main/LICENSE](https://raw.githubusercontent.com/Geonovum/IMGeo/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/IMGeo/master/LICENSE](https://raw.githubusercontent.com/Geonovum/IMGeo/master/LICENSE)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/Geonovum/IMGeo](https://github.com/Geonovum/IMGeo)
+  > Geonovum / IMGeo Public ... BGT|IMGeo standaarden ... About IMGeo volgens mappenstructuur op register.geostandaarden.nl
+  - *De bron bevestigt dat de repository Geonovum/IMGeo het BGT|IMGeo informatiemodel bevat. De CC-BY-4.0 licentie wordt nergens in de aangeleverde brontekst vermeld; er is geen licentie-informatie zichtbaar in de weergegeven GitHub-pagina.*
+
+### `geo-0022` — SKILL.md:74 *(§ Belangrijke Repositories)*
+
+> Geonovum/MIM-Werkomgeving bevat het Metamodel Informatie Modellering en is uitgebracht onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MIM repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/MIM-Werkomgeving/main/LICENSE](https://raw.githubusercontent.com/Geonovum/MIM-Werkomgeving/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/Geonovum/MIM-Werkomgeving/master/LICENSE](https://raw.githubusercontent.com/Geonovum/MIM-Werkomgeving/master/LICENSE)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (high) — [https://github.com/Geonovum/MIM-Werkomgeving](https://github.com/Geonovum/MIM-Werkomgeving)
+  > Dit is de repository van het Metamodel Informatie Modellering (MIM). Hierin staat de werkversie van het MIM.
+  - *De bron bevestigt dat de repository het Metamodel Informatie Modellering bevat. Er is echter geen vermelding van een CC-BY-4.0 licentie in de aangeleverde brontekst. Het licentiedeel kan dus niet worden ondersteund.*
 
 ## GROUNDED — minstens één bron ondersteunt de claim (11)
 
@@ -179,7 +181,7 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status geo-standaarden
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
-  > De Geo-standaarden op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie bestaan thans uit: Nederlands metadataprofiel op ISO 19115 voor geografie, versie 2.1.0 [...] NEN 3610:2022 [...] ISO 19136:2007 [...] GeoPackage 1.3.1 [...] OGC-API – Features Part 1 [...] OGC-API – Tiles - Part 1: Core
+  > De Geo-standaarden op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie bestaan thans uit: Nederlands metadataprofiel op ISO 19115 voor geografie, versie 2.1.0 [...] NEN 3610:2022 [...] ISO 19136:2007 [...] GeoPackage 1.3.1 [...]
 
 ### `geo-0004` — SKILL.md:26 *(§ Forum Standaardisatie Status)*
 
@@ -190,19 +192,9 @@
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
   > Op 19 september 2024 stemde het OBDO in met het verplichten van OGC-API – Features Part 1: Core en Part 2: Coordinate Reference Systems by Reference en OGC-API – Tiles - Part 1: Core door plaatsing op de 'pas toe of leg uit'-lijst en het aanbevelen van Nederlands WFS profiel 1.1 [...] en Nederlands profiel op ISO 19128 [...] (WMS) door plaatsing op de lijst aanbevolen standaarden.
 
-### `geo-0005` — SKILL.md:32 *(§ Forum Standaardisatie Status)*
-
-> GML is verplicht (pas-toe-of-leg-uit) als data-encoding standaard onderdeel van het Geo-Standaarden-pakket.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
-
-- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
-  > ISO 19136:2007 Geographic information - Geography Markup Language (GML), versie 2007 (geen specifiek toepassingsgebied)
-  - *GML (ISO 19136:2007) staat expliciet op de 'pas toe of leg uit'-lijst. Dat er geen specifiek toepassingsgebied wordt vermeld is opvallend, maar de opname op de lijst is duidelijk.*
-
 ### `geo-0006` — SKILL.md:33 *(§ Forum Standaardisatie Status)*
 
-> OGC API Features is verplicht (pas-toe-of-leg-uit) als REST API service onderdeel van het Geo-Standaarden-pakket.
+> OGC API Features is verplicht (pas-toe-of-leg-uit) als REST API service standaard onderdeel van het Geo-Standaarden-pakket.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
 
@@ -211,7 +203,7 @@
 
 ### `geo-0007` — SKILL.md:34 *(§ Forum Standaardisatie Status)*
 
-> OGC API Tiles is verplicht (pas-toe-of-leg-uit) als tileservice onderdeel van het Geo-Standaarden-pakket.
+> OGC API Tiles is verplicht (pas-toe-of-leg-uit) als tileservice standaard onderdeel van het Geo-Standaarden-pakket.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie verplichte geo-standaarden
 
@@ -226,6 +218,7 @@
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
   > NEN 3610:2022 (nl) Basismodel Geo-informatie - Termen, definities, relaties en algemene regels voor de uitwisseling van informatie over aan de aarde gerelateerde ruimtelijke objecten, versie 2022 (specifiek toepassingsgebied : metadatering van geografische datasets en dataset series)
+  - *De bron noemt 'informatiemodel' niet letterlijk, maar NEN 3610 is beschreven als 'Basismodel Geo-informatie' en staat op de verplichte lijst. De typering 'informatiemodel' is een correcte parafrase.*
 
 ### `geo-0009` — SKILL.md:36 *(§ Forum Standaardisatie Status)*
 
@@ -238,45 +231,66 @@
 
 ### `geo-0010` — SKILL.md:38 *(§ Forum Standaardisatie Status)*
 
-> WMS is sinds september 2024 verplaatst van verplicht naar aanbevolen als viewservice.
+> WMS is sinds september 2024 verplaatst van verplicht naar aanbevolen (als viewservice).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status WMS
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
   > Op 19 september 2024 stemde het OBDO in met [...] het aanbevelen van [...] Nederlands profiel op ISO 19128 Geographic information - Web Map Server Interface (WMS) door plaatsing op de lijst aanbevolen standaarden.
-  - *De bron bevestigt dat WMS naar 'aanbevolen' is gegaan per september 2024. Dat het eerder verplicht was staat niet expliciet in deze tekst, maar de verplaatsing naar aanbevolen is duidelijk.*
+  - *De bron bevestigt dat WMS per september 2024 is verplaatst naar de aanbevolen lijst. Dat het daarvoor verplicht was staat niet expliciet in de bron, maar de beweging van verplicht naar aanbevolen is consistent met de septemberbeslissing die de bron beschrijft.*
 
 ### `geo-0011` — SKILL.md:38 *(§ Forum Standaardisatie Status)*
 
-> WFS is sinds september 2024 verplaatst van verplicht naar aanbevolen als downloadservice.
+> WFS is sinds september 2024 verplaatst van verplicht naar aanbevolen (als downloadservice).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status WFS
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/geo-standaarden)
   > Op 19 september 2024 stemde het OBDO in met [...] het aanbevelen van Nederlands WFS profiel 1.1 op ISO 19142 voor Web Feature Services 2.0, versie 1.1 (WFS) [...] door plaatsing op de lijst aanbevolen standaarden.
-  - *De bron bevestigt dat WFS naar 'aanbevolen' is gegaan per september 2024. Dat het eerder verplicht was staat niet expliciet in deze tekst, maar de verplaatsing naar aanbevolen is duidelijk.*
+  - *Zelfde redenering als geo-0010: de bron bevestigt plaatsing op de aanbevolen lijst per september 2024.*
 
-### `geo-0014` — SKILL.md:69 *(§ Belangrijke Repositories)*
+### `geo-0016` — SKILL.md:82 *(§ Aanvullende Standaarden)*
 
-> De Geonovum/ogc-checker repository is een validatietool voor OGC services en heeft de EUPL-1.2 licentie.
+> Het Raamwerk Geo-Standaarden is een overzichtsdocument dat beschrijft hoe alle geo-standaarden samenhangen, gepubliceerd op docs.geostandaarden.nl/rwgs/rw/.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ogc-checker repository
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Raamwerk Geo-Standaarden
 
-- **SUPPORTED** (high) — [https://github.com/Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker)
-  > Validates JSON-FG documents and OGC API endpoints against OGC specifications. [...] License EUPL-1.2
+- **SUPPORTED** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
+  > "Het Raamwerk van Geostandaarden helpt daarbij. Het benoemt de internationale en nationale standaarden die voor Nederland binnen het geo-domein van toepassing zijn voor aansluiting met andere domeinen." De bron is gepubliceerd op https://docs.geostandaarden.nl/rwgs/rw/ zoals vermeld in de header.
+  - *De claim dat het een overzichtsdocument is dat beschrijft hoe alle geo-standaarden samenhangen en gepubliceerd op docs.geostandaarden.nl/rwgs/rw/ wordt volledig bevestigd door de bron zelf.*
+- **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+  - *De brontekst gaat uitsluitend over GeoPackage. Het Raamwerk Geo-Standaarden en docs.geostandaarden.nl worden niet genoemd.*
+- **NOT_FOUND** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
+  - *De bron gaat over NL-SBB en bevat geen informatie over het Raamwerk Geo-Standaarden of docs.geostandaarden.nl/rwgs/rw/.*
 
-### `geo-0022` — SKILL.md:84 *(§ Aanvullende Standaarden)*
+### `geo-0017` — SKILL.md:84 *(§ Aanvullende Standaarden)*
 
-> NL-SBB is een standaard voor het beschrijven van begrippen, gepubliceerd op docs.geostandaarden.nl/nl-sbb/nl-sbb/.
+> NL-SBB is de standaard voor het beschrijven van begrippen, gepubliceerd op docs.geostandaarden.nl/nl-sbb/nl-sbb/.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL-SBB standaard
 
 - **SUPPORTED** (high) — [https://docs.geostandaarden.nl/rwgs/rw](https://docs.geostandaarden.nl/rwgs/rw)
-  > Standaard voor het Beschrijven van Begrippen [ SBB ] [...] URL: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/
-  - *De bron vermeldt SBB (Standaard voor het Beschrijven van Begrippen) meerdere malen en geeft exact de URL docs.geostandaarden.nl/nl-sbb/nl-sbb/ in de referenties. De claim gebruikt de naam 'NL-SBB' terwijl de bron 'SBB' of 'NL-SBB' gebruikt; dit is dezelfde standaard.*
+  > "[SBB] Standaard voor het Beschrijven van Begrippen . Geonovum. 2024-10-10. Vastgestelde versie. URL: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/"
+  - *De bron noemt de SBB expliciet als 'Standaard voor het Beschrijven van Begrippen' met exact de genoemde URL. De afkorting NL-SBB wordt in de bron ook gebruikt ('NL-SBB' verschijnt in de tekst als verwijzing naar dezelfde standaard).*
 - **SUPPORTED** (high) — [https://docs.geostandaarden.nl/nl-sbb/nl-sbb](https://docs.geostandaarden.nl/nl-sbb/nl-sbb)
-  > NL-SBB - Standaard voor het beschrijven van begrippen Geonovum Standaard Vastgestelde versie 10 oktober 2024 [...] Deze versie: https://docs.geostandaarden.nl/nl-sbb/def-st-nl-sbb-20241010 Laatst gepubliceerde versie: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/
-  - *De bron bevestigt expliciet dat NL-SBB een standaard is voor het beschrijven van begrippen, gepubliceerd op docs.geostandaarden.nl/nl-sbb/nl-sbb/.*
+  > NL-SBB - Standaard voor het beschrijven van begrippen Geonovum Standaard Vastgestelde versie 10 oktober 2024 [...] Laatste gepubliceerde versie: https://docs.geostandaarden.nl/nl-sbb/nl-sbb/
+  - *De brontekst bevestigt expliciet dat NL-SBB de standaard is voor het beschrijven van begrippen en gepubliceerd is op docs.geostandaarden.nl/nl-sbb/nl-sbb/.*
 - **NOT_FOUND** (high) — [https://www.geonovum.nl/geo-standaarden/geopackage](https://www.geonovum.nl/geo-standaarden/geopackage)
+  - *De brontekst gaat uitsluitend over GeoPackage. NL-SBB wordt niet genoemd.*
+
+### `geo-0018` — SKILL.md:69 *(§ Belangrijke Repositories)*
+
+> De Geonovum ogc-checker (github.com/Geonovum/ogc-checker) is een validatietool voor OGC services, uitgebracht onder EUPL-1.2 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Geonovum ogc-checker repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://raw.githubusercontent.com/Geonovum/ogc-checker/main/LICENSE](https://raw.githubusercontent.com/Geonovum/ogc-checker/main/LICENSE)
+  > EUROPEAN UNION PUBLIC LICENCE v. 1.2 EUPL © the European Union 2007, 2016 This European Union Public Licence (the 'EUPL') applies to the Work (as defined below) which is provided under the terms of this Licence.
+  - *De bron bevestigt dat de EUPL v1.2 licentie van toepassing is op dit werk (het LICENSE-bestand van de ogc-checker repository). Het deel over 'validatietool voor OGC services' wordt niet door de brontekst bevestigd — een LICENSE-bestand bevat geen beschrijving van de functionaliteit van de software.*
+- **PARTIALLY_SUPPORTED** (high) — [https://raw.githubusercontent.com/Geonovum/ogc-checker/master/LICENSE](https://raw.githubusercontent.com/Geonovum/ogc-checker/master/LICENSE)
+  > EUROPEAN UNION PUBLIC LICENCE v. 1.2 EUPL © the European Union 2007, 2016 This European Union Public Licence (the 'EUPL') applies to the Work (as defined below) which is provided under the terms of this Licence.
+  - *De bron bevestigt dat de EUPL v1.2 licentie van toepassing is op de ogc-checker repository (het bestand is afkomstig van github.com/Geonovum/ogc-checker/master/LICENSE). Dat de tool een validatietool voor OGC services is, wordt niet vermeld in deze licentiefile — een LICENSE-bestand bevat geen functionele beschrijving van de software.*
+- **SUPPORTED** (high) — [https://github.com/Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker)
+  > Geonovum OGC Checker Validates JSON-FG documents and OGC API endpoints against OGC specifications. [...] License EUPL-1.2
 
 </details>


### PR DESCRIPTION
## Beschrijving

Voegt per skill een gegenereerde `audit.md` toe plus de audit-zichtbaarheidsworkflow.

**Waarom nu:** de audit-pipeline detecteerde de verzonnen PDOK-API-key al in mei, maar de bevinding stond alleen in een gitignore'd JSON in een sibling-repo. Niemand opende die. Door `audit.md` in de repo te committen wordt elke bevinding zichtbaar in PR-diffs en code review, en kan de workflow er een label/comment op zetten.

**Over het volume:** `UNSUPPORTED_ASSERTION` = stellige bewering zonder enige bronsteun. Er zijn er veel. Dit is bewust een triage-oppervlak, geen lijst bewezen fouten — een groot deel is waarschijnlijk waar-maar-onbronbaar (verkeerde of ontbrekende kandidaat-bron, dezelfde oorzaak als bij PDOK). De waardevolle naalden zijn de specifieke checkbare claims: versienummers, licenties, exacte waarden.

`audit.md` is gegenereerd (markdownlint-disabled, niet handmatig bewerken — pas de skill aan en regenereer).

## Checklist

- [x] Geen hardcoded paden of persoonlijke gegevens
- [x] Workflow is niet-blokkerend
## Status: post-fix, niet meer stale

De 6 geo audit.md zijn opnieuw gegenereerd met de cache-TTL-fix actief (verse bron-fetch i.p.v. verouderde mei-cache).

- **geo-inspire: nu 0 CONTRADICTED.** De eerdere CC-BY-ND 'tegenspraak' was een false positive door een verouderde bron-cache (de handreiking wijzigde van licentie ná de eerste fetch). De verse fetch corrigeert dit vanzelf — de skill was steeds correct. Dit is precies de bug die de cache-TTL-fix in audit-tooling oplost.
- **Bekende rest-ruis: geo-api-0022** (WGS84/EPSG:4326 asvolgorde) staat nog als CONTRADICTED, maar de skill is correct (live geverifieerd tegen epsg.io: EPSG:4326 = lat,lon). De audit over-interpreteert een CRS84-vermelding in de bron als tegenspraak. Niet in de skill gefixt want de skill klopt; bewust gemeld als bekende false positive, niet als te fixen bevinding.