### PR TITLE
fix(geo-api): expliciet onderscheid EPSG:4326 vs CRS84 asvolgorde

### DIFF
--- a/skills/geo-api/reference.md
+++ b/skills/geo-api/reference.md
@@ -16,7 +16,12 @@ Deze pagina bevat aanvullende technische details over OGC-protocollen, coördina
 
 ### Coördinaatvolgorde
 
-Let op: de coördinaatvolgorde verschilt per protocol en CRS.
+Let op: de coördinaatvolgorde verschilt per protocol en CRS. `EPSG:4326` en
+`CRS84` verwijzen beide naar WGS 84, maar zijn niet inwisselbaar: `EPSG:4326`
+heeft asvolgorde lat/lon (breedte, lengte) volgens de EPSG-definitie, terwijl
+`CRS84` (`OGC:CRS84`, de standaard-CRS van OGC API Features) lon/lat aanhoudt.
+Een bron die alleen `CRS84` (lon/lat) noemt, spreekt de `EPSG:4326`-asvolgorde
+dus niet tegen — het zijn twee verschillende CRS-identifiers voor hetzelfde datum.
 
 - **WMS 1.3.0**: Volgt de CRS-definitie. Voor EPSG:4326 is dat lat/lon (y,x). Voor EPSG:28992 is dat x,y.
 - **WFS 2.0**: Volgt de CRS-definitie, tenzij anders geconfigureerd.


### PR DESCRIPTION
## Wat

`skills/geo-api/reference.md`, sectie ### Coördinaatvolgorde: een expliciete uitleg toegevoegd dat `EPSG:4326` (lat/lon) en `CRS84` (lon/lat) twee verschillende CRS-identifiers zijn voor hetzelfde datum, met tegengestelde asvolgorde, en dat een bron die alleen CRS84 noemt de EPSG:4326-asvolgorde niet tegenspreekt.

De CRS-tabel zelf is **niet gewijzigd** — die was al correct.

## Waarom

De audit-sweep markeerde `geo-api-0022` ("WGS 84 heeft EPSG-code 4326 en coördinaatvolgorde lat, lon") als CONTRADICTED. Live geverifieerd tegen [epsg.io/4326](https://epsg.io/4326): EPSG:4326 = lat,lon — de skill was correct. De audit las een bron (mod-geo) die alleen CRS84 (lon/lat) documenteert als tegenspraak. Het zijn echter twee CRS-identifiers voor WGS 84 met tegengestelde asvolgorde; de bron spreekt de claim niet tegen.

In plaats van een (correcte) tabel aanpassen of dit als ruis wegzetten: het onderscheid expliciet maken. Dat is de klassieke geo-valkuil en dus inhoudelijk nuttig voor de lezer, en het haalt tegelijk de false-positive weg.

## Hoe gevonden

Audit-sweep, `claim_status: CONTRADICTED`. Live geverifieerd voor het wijzigen.

## Checklist

- [x] Live geverifieerd (epsg.io)
- [x] Correcte tabel ongewijzigd gelaten
- [x] Geen hardcoded paden of persoonlijke gegevens