### PR TITLE
fix: actualiseer ogc-checker versie naar v1.0.5

### DIFF
--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -38,7 +38,7 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.4) | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.5) | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
@@ -225,7 +225,7 @@ print(f"Gevonden: {len(data['features'])} panden")
 
 ## ogc-checker Validatie
 
-De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.4) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
+De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.5) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
 
 ```bash
 # Repo-informatie ophalen


### PR DESCRIPTION
Geonovum/ogc-checker is gebumpt van v1.0.4 naar v1.0.5 (o.a. JSON-FG ruleset naar v1.0). De geo-api skill noemde nog v1.0.4 op twee plekken; bijgewerkt naar v1.0.5.

Gevonden via monitoring issue #254.