### PR TITLE
chore: bump ogc-checker version pin naar v1.0.7

### DIFF
--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -38,7 +38,7 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.5) | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.7) | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
@@ -225,7 +225,7 @@ print(f"Gevonden: {len(data['features'])} panden")
 
 ## ogc-checker Validatie
 
-De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.5) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
+De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.7) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
 
 ```bash
 # Repo-informatie ophalen


### PR DESCRIPTION
ogc-checker is geüpdatet van v1.0.5 naar v1.0.7. De wijzigingen zijn bugfixes (false-positive types-schemas/geometry validaties, gerepareerde doc-links) en dependabot-bumps, geen nieuwe of verwijderde checks. De skill beschrijft de tool functioneel; alleen de versie-pin in geo-api/SKILL.md (twee plekken) is bijgewerkt.

Sluit #268