### PR TITLE
fix: werk ogc-checker versie-pin bij naar v1.1.0

### DIFF
--- a/skills/geo-api/SKILL.md
+++ b/skills/geo-api/SKILL.md
@@ -38,7 +38,7 @@ OGC-services zijn de standaard manier om geodata beschikbaar te stellen via het 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.0.7) | [EUPL-1.2](https://eupl.eu/1.2/en) |
+| [Geonovum/ogc-checker](https://github.com/Geonovum/ogc-checker) | Validatietool voor OGC services (v1.1.0) | [EUPL-1.2](https://eupl.eu/1.2/en) |
 | [Geonovum/ogc-checker Tags](https://github.com/Geonovum/ogc-checker/tags) | Versies van ogc-checker | [EUPL-1.2](https://eupl.eu/1.2/en) |
 
 ## WMS (Web Map Service)
@@ -225,7 +225,7 @@ print(f"Gevonden: {len(data['features'])} panden")
 
 ## ogc-checker Validatie
 
-De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.0.7) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
+De [ogc-checker](https://github.com/Geonovum/ogc-checker) (v1.1.0) is een validatietool van Geonovum om OGC-services te controleren op conformiteit.
 
 ```bash
 # Repo-informatie ophalen


### PR DESCRIPTION
Geonovum heeft ogc-checker v1.1.0 getagd (15 juli). Deze PR werkt de versie-pin in geo-api/SKILL.md bij van v1.0.7 naar v1.1.0 (twee plekken: repository-tabel en validatie-sectie).

Wijzigingen in v1.1.0 (geen verdere skill-impact, de skill beschrijft de checker functioneel):

- Standard → Version model en Changesets releasing (#817)
- OGC API Processes ruleset gelijkgetrokken met de laatste v2.0 draft 18-062r3 (#813)
- Raw example fixtures en JSON-FG conformance-melding (#802)

Sluit de monitoring-issue #300.